### PR TITLE
Feature 73: CI/CD for Database Changes

### DIFF
--- a/apps/server-asset-sg/docker/Dockerfile
+++ b/apps/server-asset-sg/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine as api-builder
 
+ENV NODE_ENV=development
+
 WORKDIR /app
 COPY . .
 
@@ -10,8 +12,13 @@ RUN npx nx build server-asset-sg
 # final image build
 FROM node:20-alpine
 
+ENV NODE_ENV=production
+
 WORKDIR /app
 COPY --from=api-builder /app/dist/apps/server-asset-sg .
 COPY --from=api-builder /app/node_modules ./node_modules
+COPY apps/server-asset-sg/docker/start.sh start.sh
+RUN chmod +x start.sh
 
-CMD ["node", "main.js"]
+ENTRYPOINT ["sh"]
+CMD ["start.sh"]

--- a/apps/server-asset-sg/docker/start.sh
+++ b/apps/server-asset-sg/docker/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npx prisma migrate deploy || exit 1
+node main.js


### PR DESCRIPTION
Resolves #73.

Replaces the startup command of the API's Docker image with a shell script that runs `prisma migrate deploy` before starting the application itself.