### PR TITLE
Feature 33: Bug - Alternativ-ID's werden nicht gespeichert

### DIFF
--- a/libs/asset-editor/src/lib/components/asset-editor-tab-general/asset-editor-tab-general.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tab-general/asset-editor-tab-general.component.ts
@@ -118,13 +118,12 @@ export class AssetEditorTabGeneralComponent implements OnInit {
                 this.idForm.controls['description'].reset(undefined, { emitEvent: false });
                 this.idForm.controls['description'].disable({ emitEvent: false });
             } else if (this.idForm.controls['description'].disabled) {
-                    this.idForm.controls['description'].enable({ emitEvent: false });
-                    this.idForm.controls['description'].markAsTouched();
-                    if (this._idFormDescription) {
-                        this._focusMonitor.focusVia(this._idFormDescription?.nativeElement, 'program');
-                    }
+                this.idForm.controls['description'].enable({ emitEvent: false });
+                this.idForm.controls['description'].markAsTouched();
+                if (this._idFormDescription) {
+                    this._focusMonitor.focusVia(this._idFormDescription?.nativeElement, 'program');
                 }
-
+            }
 
             // sync the idForm state with the ids control in the general form
             if (this._state.get().currentlyEditedIdIndex !== -1) {
@@ -144,12 +143,12 @@ export class AssetEditorTabGeneralComponent implements OnInit {
                         this._form.markAsDirty();
                     }
                 } else if (ids.length > 0) {
-                        this._form.controls.ids.setValue(
-                            ids.filter((_, i) => i !== this._state.get().currentlyEditedIdIndex),
-                            { emitEvent: false },
-                        );
-                        this._form.markAsDirty();
-                    }
+                    this._form.controls.ids.setValue(
+                        ids.filter((_, i) => i !== this._state.get().currentlyEditedIdIndex),
+                        { emitEvent: false },
+                    );
+                    this._form.markAsDirty();
+                }
 
             }
         });
@@ -206,13 +205,12 @@ export class AssetEditorTabGeneralComponent implements OnInit {
     }
 
     public _saveIdFormClicked() {
-        const currentlyEditedIdIndex = this._state.get().currentlyEditedIdIndex;
-        if (currentlyEditedIdIndex !== -1) {
-            this._form.controls.ids.setValue(
-                this._form.controls.ids.value.map((v, i) =>
-                    i === currentlyEditedIdIndex ? { ...this.idForm.getRawValue(), idId: O.none } : v,
-                ),
-            );
+        const i = this._state.get().currentlyEditedIdIndex;
+        this._state.set({ userInsertMode: false, currentlyEditedIdIndex: -1 });
+        if (i >= 0) {
+            const newIds = [...this._form.controls.ids.value];
+            newIds[i] = { ...this.idForm.getRawValue(), idId: O.none }
+            this._form.controls.ids.setValue(newIds);
             this._form.markAsDirty();
         } else {
             this._form.controls.ids.setValue([
@@ -222,7 +220,6 @@ export class AssetEditorTabGeneralComponent implements OnInit {
             this._form.markAsDirty();
         }
         this.idForm.reset();
-        this._state.set({ userInsertMode: false, currentlyEditedIdIndex: -1 });
     }
 
     public _deleteIdClicked(index: number) {


### PR DESCRIPTION
Resolves #33.

The bug can reproduced simply by adding a new alternative id, and then editing + saving an existing one. This will cause the id that is being edited to be removed from the form.

**Cause:**  
The fields used to create/edit an alternative id are in a standalone form (i.e. it's not part of the big form that controls the entire asset view). Instead, it's a small form that is "manually" synced back to the big form via observables. This is quite an opaque task with a lot of corner cases. In this case, a subscriber that syncs the two forms was triggered after saving the existing id, but before resetting the small form back to a non-edit state. This caused the subscriber to perceive the id as being "new", and the form as "cancelled", which is why it removes the "cancelled" id.

**Solution:**  
Reorder the state updates so that the subscriber is executed only after the form has been fully reset.