### PR TITLE
Hotfix: Build with Production Configuration

### DIFF
--- a/apps/server-asset-sg/project.json
+++ b/apps/server-asset-sg/project.json
@@ -13,7 +13,7 @@
                         "command": "npx nx run server-asset-sg:gen-prisma-client"
                     },
                     {
-                        "command": "npx nx run server-asset-sg:build-app"
+                        "command": "npx nx run server-asset-sg:build-app:production"
                     },
                     {
                         "command": "npx shx cp apps/server-asset-sg/docker/* dist/apps/server-asset-sg"


### PR DESCRIPTION
Always use the `production` configuration when running the `server-asset-sg:build` command.