### PR TITLE
Fix: Case Insensitive Search

### DIFF
--- a/apps/server-asset-sg/src/app/search/asset-search-service.ts
+++ b/apps/server-asset-sg/src/app/search/asset-search-service.ts
@@ -385,7 +385,7 @@ export class AssetSearchService {
           should: [
             {
               query_string: {
-                query: query,
+                query: normalizeFieldQuery(query),
                 fields: scope,
               },
             },
@@ -604,7 +604,7 @@ const mapQueryToElasticDsl = (query: AssetSearchQuery): QueryDslQueryContainer =
         should: query.text.includes(':')
           ? {
             query_string: {
-              query: query.text,
+              query: normalizeFieldQuery(query.text),
               fields: scope,
             },
           }
@@ -761,3 +761,11 @@ interface PageOptions {
 const escapeElasticQuery = (query: string): string => {
   return query.replace(/(&&|\|\||!|\(|\)|\{|}|\[|]|\^|"|~|\*|\?|:|\\)/, '\\$1');
 };
+
+const normalizeFieldQuery = (query: string): string => (
+  query
+    .replace(/title(_*)public:/i, 'titlePublic:')
+    .replace(/title(_*)original:/i, 'titleOriginal:')
+    .replace(/contact(_*)ame:/i, 'contactNames:')
+    .replace(/sgs(_*)id:/i, 'sgsId:')
+);


### PR DESCRIPTION
Allow searches on specific fields to use case-insensitive field names by normalizing the names before running the search.