### PR TITLE
Feature 123: Devops-Angleich

### DIFF
--- a/.github/actions/create-image/action.yaml
+++ b/.github/actions/create-image/action.yaml
@@ -1,12 +1,17 @@
-name: "create docker image"
+name: "Create Docker Image"
 description: "Builds a docker image and tags it"
 inputs:
   IMAGE_NAME:
     description: "The image name"
     required: true
-  TAG:
+  VERSION:
     description: "The version of the image"
     required: true
+  TAG:
+    description: "The tag of the image, in addition to the version"
+    required: true
+  OTHER_TAGS:
+    description: "Any additional tags, passed directly to docker/metadata-action"
   DOCKERFILE:
     description: "The path to the Dockerfile"
     required: true
@@ -33,11 +38,14 @@ runs:
         images: ${{ inputs.IMAGE_NAME }}
         labels: |
           org.opencontainers.image.created=${{ env.COMMITED_AT }}
+          org.opencontainers.image.version=v${{ inputs.VERSION }}
           org.opencontainers.image.maintainer=EBP Schweiz AG
         flavor: |
-          latest=false
+          latest=${{ inputs.TAG == 'latest' }}
         tags: |
-          ${{ inputs.TAG }}
+          type=raw,value=${{ inputs.TAG }}
+          type=raw,value=${{ inputs.VERSION }}
+          ${{ inputs.OTHER_TAGS }}
 
     - name: Log in to the GitHub container registry
       uses: docker/login-action@v3

--- a/.github/actions/create-image/action.yaml
+++ b/.github/actions/create-image/action.yaml
@@ -63,3 +63,5 @@ runs:
         tags: ${{ steps.meta-data.outputs.tags }}
         labels: ${{ steps.meta-data.outputs.labels }}
         no-cache: true
+        build-args: |
+          APP_VERSION=${{ inputs.VERSION }}

--- a/.github/actions/tag-commit/action.yaml
+++ b/.github/actions/tag-commit/action.yaml
@@ -1,0 +1,34 @@
+name: "Tag Commit"
+description: "Creates or updates a commit tag"
+inputs:
+  TAG_NAME:
+    description: "The tag's name"
+    required: true
+  SHA:
+    description: "The SHA of the commit to be tagged"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create/update tag
+      uses: actions/github-script@v7
+      env:
+        TAG: ${{ inputs.TAG_NAME }}
+        SHA: ${{ inputs.SHA }}
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: `refs/tags/${process.env.TAG}`,
+            sha: process.env.SHA
+          }).catch(err => {
+            if (err.status !== 422) throw err;
+            github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${process.env.TAG}`,
+              sha: process.env.SHA
+            });
+          })

--- a/.github/scripts/find-version.js
+++ b/.github/scripts/find-version.js
@@ -1,0 +1,107 @@
+const findNextVersion = (tags, branch) => {
+  const version = findMostRecentVersion(tags);
+  if (branch.startsWith("feature/")) {
+    // It's a minor feature.
+
+    // If the previous version was a full release or a patch dev release,
+    // we are a completely new minor dev release.
+    // Otherwise, the previous version was itself a minor dev release,
+    // and we can reuse its number.
+    if (version.preRelease == null || version.patch !== 0) {
+      version.minor += 1;
+      version.patch = 0;
+    }
+  } else {
+    // It's a patch.
+
+    // If the previous version was a full release,
+    // we are a completely new patch dev release.
+    // Otherwise, we can simply reuse the previous version's number.
+    if (version.preRelease == null) {
+      version.patch += 1;
+    }
+  }
+
+  version.preRelease ??= 0;
+  version.preRelease += 1;
+  return version;
+};
+
+const findMostRecentVersion = (tags) => {
+  const versions = findAllVersions(tags);
+  if (versions.length === 0) {
+    throw new Error("unable to find a valid version on current edge tag");
+  }
+  return versions[0];
+};
+
+const findOutdatedVersions = (tags, recentTag) => {
+  const recentVersion = parseVersion(recentTag);
+  if (recentVersion == null) {
+    throw new Error(`recent tag '${recentTag}' is not a version number`);
+  }
+  const versions = findAllVersions(tags);
+  return versions.filter(
+    (version) =>
+      // Select all pre-releases that appear before the most recent one.
+      version.preRelease != null && compareVersions(recentVersion, version) > 0
+  );
+};
+
+const findAllVersions = (tags) => {
+  return tags
+    .map(parseVersion)
+    .filter((it) => it != null)
+    .sort((a, b) => compareVersions(a, b) * -1);
+};
+
+const SEMANTIC_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-dev\d+)?$/;
+const parseVersion = (tag) => {
+  if (!SEMANTIC_VERSION_PATTERN.test(tag)) {
+    return null;
+  }
+  const [major, minor, patch, preRelease] = tag.split(/[.\-]/);
+  return {
+    major: parseInt(major),
+    minor: parseInt(minor),
+    patch: parseInt(patch),
+    preRelease: preRelease && parseInt(preRelease.substring(3)),
+  };
+};
+
+const compareVersions = (a, b) => {
+  if (a.major !== b.major) {
+    return a.major - b.major;
+  }
+  if (a.minor !== b.minor) {
+    return a.minor - b.minor;
+  }
+  if (a.patch !== b.patch) {
+    return a.patch - b.patch;
+  }
+  if (a.preRelease !== b.preRelease) {
+    if (a.preRelease == null) {
+      return 1;
+    }
+    if (b.preRelease == null) {
+      return -1;
+    }
+    return a.preRelease - b.preRelease;
+  }
+  return 0;
+};
+
+const makeVersionTag = ({ major, minor, patch, preRelease }) => {
+  const tag = `${major}.${minor}.${patch}`;
+  if (preRelease == null) {
+    return tag;
+  }
+  return `${tag}-dev${preRelease}`;
+};
+
+module.exports = {
+  findNextVersion,
+  findMostRecentVersion,
+  findOutdatedVersions,
+  makeVersionTag,
+};

--- a/.github/scripts/remove-packages.js
+++ b/.github/scripts/remove-packages.js
@@ -1,0 +1,51 @@
+const { Octokit } = require("@octokit/rest");
+
+const removePackageVersions = async (imageUrl, imageVersions) => {
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+  });
+
+  const [_imageHost, imageOwner, imageName] = imageUrl.split("/");
+  const imageIds = await loadOutdatedVersionIds(octokit, imageOwner, imageName, imageVersions);
+  for (const imageId of imageIds) {
+    await octokit.rest.packages.deletePackageVersionForOrg({
+      package_type: "container",
+      package_name: imageName,
+      username: imageOwner,
+      package_version_id: imageId,
+    });
+  }
+};
+
+const loadOutdatedVersionIds = async (octokit, imageOwner, imageName, versions) => {
+  let page = 0;
+  versions = new Set(versions);
+
+  const ids = new Set();
+  while (true) {
+    const response = await octokit.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
+      package_type: "container",
+      package_name: imageName,
+      username: imageOwner,
+      page,
+    });
+    if (response.data.length === 0) {
+      break;
+    }
+    for (const entry of response.data) {
+      // Match any of the requested version's ids,
+      // as well as any ids that do not have a tag anymore, i.e. are fully unused.
+      const { tags } = entry.metadata.container;
+      const matchedTags = tags.filter((tag) => versions.delete(tag));
+      if (tags.length === 0 || matchedTags.length !== 0) {
+        ids.add(entry.id);
+      }
+    }
+    page += 1;
+  }
+  return ids;
+};
+
+module.exports = {
+  removePackageVersions,
+};

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Review Dependencies
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v4
 
   # It would be cleaner and probably more performant to replace this build step
   # with either a non-emitting build or a simple type check.
@@ -145,7 +145,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./node_modules
-          key: "${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
+          key: "${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
       - name: Reset nx
         run: npx nx reset
       - name: Run build
@@ -153,6 +153,7 @@ jobs:
 
   cypress:
     runs-on: ubuntu-latest
+    if: ${{ false }}
     needs:
       - test
       - lint

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,6 +9,10 @@ on:
 
 env:
   NODE_VERSION: "20.x"
+  DB_USERNAME: postgres-test
+  DB_PASSWORD: postgres-test
+  DB_DATABASE: postgres-test
+  DATABASE_URL: postgres://postgres-test:postgres-test@localhost:5432/postgres-test?schema=public
 
 jobs:
   install:
@@ -27,29 +31,33 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: "${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}"
+          key: "${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}"
           restore-keys: |
             ${{ runner.os }}-npm-
       - name: Cache node modules
         uses: actions/cache@v4
         with:
           path: ./node_modules
-          key: "${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
+          key: "${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
           restore-keys: |
             ${{ runner.os }}-node_modules-
+      - name: Cache e2e node modules
+        uses: actions/cache@v4
+        with:
+          path: ./e2e/node_modules
+          key: "${{ runner.os }}-node_modules_e2e-${{ hashFiles('./e2e/package-lock.json') }}"
+          restore-keys: |
+            ${{ runner.os }}-node_modules_e2e-
       - name: Install node dependencies
         run: npm ci
       - name: Generate prisma types
         run: npm run prisma -- generate
+      - name: Install e2e node dependencies
+        run: cd e2e && npm ci
 
   test:
     runs-on: ubuntu-latest
     needs: install
-    env:
-      DB_USERNAME: postgres-test
-      DB_PASSWORD: postgres-test
-      DB_DATABASE: postgres-test
-      DATABASE_URL: postgres://postgres-test:postgres-test@localhost:5432/postgres-test?schema=public
     services:
       db:
         image: postgis/postgis
@@ -80,7 +88,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./node_modules
-          key: "${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
+          key: "${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
       - name: Migrate database
         run: npm run prisma -- migrate deploy
       - name: Run tests
@@ -100,7 +108,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./node_modules
-          key: "${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
+          key: "${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/schema.prisma') }}"
       - name: Run lint
         run: npm run lint
       - name: Run prettier
@@ -142,3 +150,56 @@ jobs:
         run: npx nx reset
       - name: Run build
         run: npm run build
+
+  cypress:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - lint
+      - dependency-review
+    strategy:
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # Use 2 parallel instances
+        containers: [1, 2]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Start services
+        env:
+          DB_USER: ${{ env.DB_USERNAME }}
+          DB_PASSWORD: ${{ env.DB_PASSWORD }}
+        run: |
+          cd development
+          docker compose up -d db oidc elasticsearch
+      - name: Setup
+        run: |
+          npm run prisma -- reset -f
+          # npm run start:server &> /dev/null &
+      - name: Restore cached e2e node modules
+        uses: actions/cache/restore@v4
+        with:
+          path: ./e2e/node_modules
+          key: "${{ runner.os }}-node_modules_e2e-${{ hashFiles('./e2e/package-lock.json') }}"
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        with:
+          command: |
+            npx cypress run \
+              --record \
+              --parallel \
+              --key ${{ secrets.CYPRESS_RECORD_KEY }} \
+              --ci-build-id ${{ github.repository }}-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          build: npm run build
+          start: npm start
+          wait-on: "http://localhost:4200"
+          wait-on-timeout: 120
+        env:
+          VITE_APP_VERSION: 0.0.99+dev
+          TZ: Europe/Zurich
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stop services
+        run: |
+          cd development
+          docker compose down

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,10 +1,11 @@
-name: build
+name: Code Quality
 
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - "**"
-  workflow_dispatch:
+      - "!main"
 
 env:
   NODE_VERSION: "20.x"
@@ -105,6 +106,14 @@ jobs:
       - name: Run prettier
         run: npx prettier --check .
 
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Review Dependencies
+        uses: actions/dependency-review-action@v3
+
   # It would be cleaner and probably more performant to replace this build step
   # with either a non-emitting build or a simple type check.
   # We only have `build` available for now,
@@ -114,9 +123,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs:
-      - install
       - test
       - lint
+      - dependency-review
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -133,127 +142,3 @@ jobs:
         run: npx nx reset
       - name: Run build
         run: npm run build
-
-  build_and_push_app:
-    name: "build and push app"
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Create image
-        uses: ./.github/actions/create-image
-        with:
-          IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-app
-          TAG: edge
-          DOCKERFILE: ./apps/client-asset-sg/docker/Dockerfile
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build_and_push_api:
-    name: "build and push api"
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Create image
-        uses: ./.github/actions/create-image
-        with:
-          IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-api
-          TAG: edge
-          DOCKERFILE: ./apps/server-asset-sg/docker/Dockerfile
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  tag_edge_commit:
-    name: "tag edge commit"
-    needs:
-      - build_and_push_app
-      - build_and_push_api
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create/update tag
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/edge',
-              sha: context.sha
-            }).catch(err => {
-              if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/edge',
-                sha: context.sha
-              });
-            })
-
-  tag_rc_image_app:
-    name: tag rc image app
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to GitHub Packages
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
-
-      - name: Pull docker image
-        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-app:edge
-
-      - name: Tag docker image
-        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-app:edge ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
-
-      - name: Push docker image
-        run: docker push ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
-
-  tag_rc_image_api:
-    name: tag rc image api
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to GitHub Packages
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
-
-      - name: Pull docker image
-        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-api:edge
-
-      - name: Tag docker image
-        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-api:edge ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
-
-      - name: Push docker image
-        run: docker push ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
-
-  tag_rc_commit:
-    name: "tag rc commit"
-    needs:
-      - tag_rc_image_app
-      - tag_rc_image_api
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create/update tag
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/release-candidate',
-              sha: context.sha
-            }).catch(err => {
-              if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/release-candidate',
-                sha: context.sha
-              });
-            })

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,11 @@
-name: code-ql
+name: CodeQL
 
 on:
   push:
     branches:
       - develop
+
   workflow_dispatch:
-  schedule:
-    - cron: "35 4 * * 5"
 
 jobs:
   analyze:

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -5,17 +5,38 @@ on:
     branches:
       - "develop"
 
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: |
+          Version number (e.g. 1.2.3-dev1).
+          Leave empty to determine the next version automatically.
+        required: false
+        default: ""
+      is-edge:
+        type: boolean
+        description: "Tag the commit and published image with `edge`."
+        default: true
+
+permissions: write-all
+
+env:
+  IS_EDGE: ${{ github.event_name == 'push' || github.event.inputs.is-edge == 'true' }}
+
 jobs:
   determine_version:
     name: "determine version"
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.find_version.outputs.result }}
+      version: ${{ steps.find_version.outputs.result || github.event.inputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        if: ${{ github.event.inputs.version == '' }}
       - name: Get tags of edge commit
         id: get_edge_tags
+        if: ${{ github.event.inputs.version == '' }}
         run: |
           git fetch --tags
           EDGE_COMMIT=$(git rev-list -n 1 edge)
@@ -24,6 +45,7 @@ jobs:
           echo "edge_tags=$EDGE_TAGS" >> "$GITHUB_OUTPUT"
       - name: Find next version
         id: find_version
+        if: ${{ github.event.inputs.version == '' }}
         uses: actions/github-script@v7
         env:
           EDGE_TAGS: ${{ steps.get_edge_tags.outputs.edge_tags }}
@@ -32,8 +54,23 @@ jobs:
           script: |
             const { findNextVersion } = require('./.github/scripts/find-version.js');
             const tags = process.env.EDGE_TAGS.split(',');
-            const branch = context.ref.replace('refs/heads/', '');
-            const version = findNextVersion(tags, branch);
+            const targetBranch = context.payload.ref.replace('refs/heads/', '');
+
+            const pullRequests = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              base: targetBranch,
+              sort: 'updated',
+              direction: 'desc'
+            });
+
+            const mergedPullRequest = pullRequests.data.find(pr => pr.merge_commit_sha === context.payload.after);
+            const sourceBranch = mergedPullRequest == null
+              ? targetBranch
+              : mergedPullRequest.head.ref.replace('refs/heads/', '')
+
+            const version = findNextVersion(tags, sourceBranch);
             return `${version.major}.${version.minor}.${version.patch}-dev${version.preRelease}`;
 
   build_and_push_api:
@@ -48,7 +85,7 @@ jobs:
         uses: ./.github/actions/create-image
         with:
           IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-api
-          TAG: edge
+          TAG: ${{ env.IS_EDGE == 'true' && 'edge' || '' }}
           VERSION: ${{ needs.determine_version.outputs.version }}
           DOCKERFILE: ./apps/server-asset-sg/docker/Dockerfile
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +102,7 @@ jobs:
         uses: ./.github/actions/create-image
         with:
           IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-app
-          TAG: edge
+          TAG: ${{ env.IS_EDGE == 'true' && 'edge' || '' }}
           VERSION: ${{ needs.determine_version.outputs.version }}
           DOCKERFILE: ./apps/client-asset-sg/docker/Dockerfile
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,6 +118,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: tag edge
+        if: ${{ env.IS_EDGE == 'true' }}
         uses: ./.github/actions/tag-commit
         with:
           TAG_NAME: edge

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -1,0 +1,92 @@
+name: Publish Edge
+
+on:
+  push:
+    branches:
+      - "develop"
+
+jobs:
+  determine_version:
+    name: "determine version"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.find_version.outputs.result }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get tags of edge commit
+        id: get_edge_tags
+        run: |
+          git fetch --tags
+          EDGE_COMMIT=$(git rev-list -n 1 edge)
+          EDGE_TAGS=$(printf "%s," $(git tag --contains $EDGE_COMMIT))
+          EDGE_TAGS=${EDGE_TAGS%,}
+          echo "edge_tags=$EDGE_TAGS" >> "$GITHUB_OUTPUT"
+      - name: Find next version
+        id: find_version
+        uses: actions/github-script@v7
+        env:
+          EDGE_TAGS: ${{ steps.get_edge_tags.outputs.edge_tags }}
+        with:
+          result-encoding: string
+          script: |
+            const { findNextVersion } = require('./.github/scripts/find-version.js');
+            const tags = process.env.EDGE_TAGS.split(',');
+            const branch = context.ref.replace('refs/heads/', '');
+            const version = findNextVersion(tags, branch);
+            return `${version.major}.${version.minor}.${version.patch}-dev${version.preRelease}`;
+
+  build_and_push_api:
+    name: "build and push api"
+    needs:
+      - determine_version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create image
+        uses: ./.github/actions/create-image
+        with:
+          IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-api
+          TAG: edge
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          DOCKERFILE: ./apps/server-asset-sg/docker/Dockerfile
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_push_app:
+    name: "build and push app"
+    needs:
+      - determine_version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create image
+        uses: ./.github/actions/create-image
+        with:
+          IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-app
+          TAG: edge
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          DOCKERFILE: ./apps/client-asset-sg/docker/Dockerfile
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  tag_commit:
+    name: "tag commit"
+    needs:
+      - determine_version
+      - build_and_push_api
+      - build_and_push_app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: tag edge
+        uses: ./.github/actions/tag-commit
+        with:
+          TAG_NAME: edge
+          SHA: ${{ github.sha }}
+      - name: tag version
+        uses: ./.github/actions/tag-commit
+        with:
+          TAG_NAME: ${{ needs.determine_version.outputs.version }}
+          SHA: ${{ github.sha }}

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -5,7 +5,20 @@ on:
     branches:
       - "main"
 
+  workflow_dispatch:
+    inputs:
+      base:
+        type: string
+        description: |
+          The tag of the commit that will be published as release-candidate.
+          Make sure that you also select that tag as the workflow's run location.
+        required: false
+        default: "edge"
+
 permissions: write-all
+
+env:
+  BASE: ${{ github.event.inputs.base || 'edge' }}
 
 jobs:
   tag_rc_image_app:
@@ -16,10 +29,10 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Pull docker image
-        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-app:edge
+        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-app:${{ env.BASE }}
 
       - name: Tag docker image
-        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-app:edge ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
+        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-app:${{ env.BASE }} ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
 
       - name: Push docker image
         run: docker push ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
@@ -32,10 +45,10 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Pull docker image
-        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-api:edge
+        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-api:${{ env.BASE }}
 
       - name: Tag docker image
-        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-api:edge ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
+        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-api:${{ env.BASE }} ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
 
       - name: Push docker image
         run: docker push ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
@@ -49,14 +62,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Get edge commit
-        id: get_edge_commit
+      - name: Get base commit
+        id: get_base_commit
         run: |
           git fetch --tags
-          EDGE_COMMIT=$(git rev-list -n 1 edge)
-          echo "sha=$EDGE_COMMIT" >> "$GITHUB_OUTPUT"
+          BASE_COMMIT=$(git rev-list -n 1 $BASE)
+          echo "sha=$BASE_COMMIT" >> "$GITHUB_OUTPUT"
       - name: tag release-candidate
         uses: ./.github/actions/tag-commit
         with:
           TAG_NAME: release-candidate
-          SHA: ${{ steps.get_edge_commit.outputs.sha }}
+          SHA: ${{ steps.get_base_commit.outputs.sha }}

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -1,0 +1,62 @@
+name: Publish Release Candidate
+
+on:
+  push:
+    branches:
+      - "main"
+
+permissions: write-all
+
+jobs:
+  tag_rc_image_app:
+    name: tag rc image app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Packages
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      - name: Pull docker image
+        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-app:edge
+
+      - name: Tag docker image
+        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-app:edge ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
+
+      - name: Push docker image
+        run: docker push ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
+
+  tag_rc_image_api:
+    name: tag rc image api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Packages
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      - name: Pull docker image
+        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-api:edge
+
+      - name: Tag docker image
+        run: docker tag ${{ vars.BASE_IMAGE_NAME }}-api:edge ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
+
+      - name: Push docker image
+        run: docker push ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
+
+  tag_rc_commit:
+    name: "tag rc commit"
+    needs:
+      - tag_rc_image_app
+      - tag_rc_image_api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get edge commit
+        id: get_edge_commit
+        run: |
+          git fetch --tags
+          EDGE_COMMIT=$(git rev-list -n 1 edge)
+          echo "sha=$EDGE_COMMIT" >> "$GITHUB_OUTPUT"
+      - name: tag release-candidate
+        uses: ./.github/actions/tag-commit
+        with:
+          TAG_NAME: release-candidate
+          SHA: ${{ steps.get_edge_commit.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,32 @@
-name: Release from main
+name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      base:
+        type: string
+        description: |
+          The tag of the commit that will be released.
+          Make sure that you also select that tag as the workflow's run location.
+        required: false
+        default: "release-candidate"
+      is-edge:
+        type: boolean
+        description: |
+          Assign the `edge` tag to this release.
+        default: true
+      is-release-candidate:
+        type: boolean
+        description: |
+          Assign the `release-candidate` tag to this release.
+        default: true
+
+permissions: write-all
+
+env:
+  BASE: ${{ github.event.inputs.base || 'release-candidate' }}
+  IS_EDGE: ${{ github.event.inputs.is-edge == 'true' }}
+  IS_RC: ${{ github.event.inputs.is-release-candidate == 'true' }}
 
 jobs:
   determine_version:
@@ -12,24 +37,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Get tags of release-candidate commit
-        id: get_rc_tags
+      - name: Get tags of base commit
+        id: get_base_tags
         run: |
           git fetch --tags
-          RC_COMMIT=$(git rev-list -n 1 release-candidate)
-          RC_TAGS=$(printf "%s," $(git tag --contains $RC_COMMIT))
-          RC_TAGS=${RC_TAGS%,}
-          echo "rc_tags=$RC_TAGS" >> "$GITHUB_OUTPUT"
+          BASE_COMMIT=$(git rev-list -n 1 release-candidate)
+          BASE_TAGS=$(printf "%s," $(git tag --contains $BASE_COMMIT))
+          BASE_TAGS=${BASE_TAGS%,}
+          echo "base_tags=$BASE_TAGS" >> "$GITHUB_OUTPUT"
       - name: Find next version
         id: find_version
         uses: actions/github-script@v7
         env:
-          RC_TAGS: ${{ steps.get_rc_tags.outputs.rc_tags }}
+          BASE_TAGS: ${{ steps.get_base_tags.outputs.base_tags }}
         with:
           result-encoding: string
           script: |
             const { findMostRecentVersion, makeVersionTag } = require('./.github/scripts/find-version.js');
-            const tags = process.env.RC_TAGS.split(',');
+            const tags = process.env.BASE_TAGS.split(',');
             const version = findMostRecentVersion(tags);
             version.preRelease = null;
             return makeVersionTag(version);
@@ -48,8 +73,8 @@ jobs:
           IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-api
           TAG: latest
           OTHER_TAGS: |
-            type=raw,value=edge
-            type=raw,value=release-candidate
+            type=raw,value=${{ env.IS_EDGE == 'true' && 'edge' || '' }}
+            type=raw,value=${{ env.IS_RC == 'true' && 'release-candidate' || '' }}
           VERSION: ${{ needs.determine_version.outputs.version }}
           DOCKERFILE: ./apps/server-asset-sg/docker/Dockerfile
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,11 +115,13 @@ jobs:
           TAG_NAME: latest
           SHA: ${{ github.sha }}
       - name: Tag release-candidate
+        if: ${{ env.IS_RC == 'true' }}
         uses: ./.github/actions/tag-commit
         with:
           TAG_NAME: release-candidate
           SHA: ${{ github.sha }}
       - name: Tag edge
+        if: ${{ env.IS_EDGE == 'true' }}
         uses: ./.github/actions/tag-commit
         with:
           TAG_NAME: edge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,106 +1,116 @@
-name: release
+name: Release from main
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version number (e.g. 1.12)"
-        required: true
+
 jobs:
-  release_app:
-    name: release app
+  determine_version:
+    name: "determine version"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.find_version.outputs.result }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get tags of release-candidate commit
+        id: get_rc_tags
+        run: |
+          git fetch --tags
+          RC_COMMIT=$(git rev-list -n 1 release-candidate)
+          RC_TAGS=$(printf "%s," $(git tag --contains $RC_COMMIT))
+          RC_TAGS=${RC_TAGS%,}
+          echo "rc_tags=$RC_TAGS" >> "$GITHUB_OUTPUT"
+      - name: Find next version
+        id: find_version
+        uses: actions/github-script@v7
+        env:
+          RC_TAGS: ${{ steps.get_rc_tags.outputs.rc_tags }}
+        with:
+          result-encoding: string
+          script: |
+            const { findMostRecentVersion, makeVersionTag } = require('./.github/scripts/find-version.js');
+            const tags = process.env.RC_TAGS.split(',');
+            const version = findMostRecentVersion(tags);
+            version.preRelease = null;
+            return makeVersionTag(version);
+
+  build_and_push_api:
+    name: "build and push api"
     needs:
-      - read_version
+      - determine_version
     runs-on: ubuntu-latest
     steps:
-      - name: Login to GitHub Packages
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create image
+        uses: ./.github/actions/create-image
+        with:
+          IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-api
+          TAG: latest
+          OTHER_TAGS: |
+            type=raw,value=edge
+            type=raw,value=release-candidate
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          DOCKERFILE: ./apps/server-asset-sg/docker/Dockerfile
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull docker image
-        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate
-
-      - name: Tag docker image
-        run: |
-          docker tag ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate ${{ vars.BASE_IMAGE_NAME }}-app:${{ inputs.VERSION }}
-          docker tag ${{ vars.BASE_IMAGE_NAME }}-app:release-candidate ${{ vars.BASE_IMAGE_NAME }}-app:latest
-
-      - name: Push docker image
-        run: |
-          docker push ${{ vars.BASE_IMAGE_NAME }}-app:${{ inputs.VERSION }}
-          docker push ${{ vars.BASE_IMAGE_NAME }}-app:latest
-
-  release_api:
-    name: release api
+  build_and_push_app:
+    name: "build and push app"
     needs:
-      - read_version
+      - determine_version
     runs-on: ubuntu-latest
     steps:
-      - name: Login to GitHub Packages
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
-
-      - name: Pull docker image
-        run: docker pull ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate
-
-      - name: Tag docker image
-        run: |
-          docker tag ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate ${{ vars.BASE_IMAGE_NAME }}-api:${{ inputs.VERSION }}
-          docker tag ${{ vars.BASE_IMAGE_NAME }}-api:release-candidate ${{ vars.BASE_IMAGE_NAME }}-api:latest
-
-      - name: Push docker image
-        run: |
-          docker push ${{ vars.BASE_IMAGE_NAME }}-api:${{ inputs.VERSION }}
-          docker push ${{ vars.BASE_IMAGE_NAME }}-api:latest
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create image
+        uses: ./.github/actions/create-image
+        with:
+          IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-app
+          TAG: latest
+          OTHER_TAGS: |
+            type=raw,value=edge
+            type=raw,value=release-candidate
+          VERSION: ${{ needs.determine_version.outputs.version }}
+          DOCKERFILE: ./apps/client-asset-sg/docker/Dockerfile
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   tag_commit:
     name: "tag commit"
     needs:
-      - release_app
-      - release_api
+      - determine_version
+      - build_and_push_api
+      - build_and_push_app
     runs-on: ubuntu-latest
     steps:
-      - name: Create/update latest tag
-        uses: actions/github-script@v7
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: tag latest
+        uses: ./.github/actions/tag-commit
         with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/latest',
-              sha: context.sha
-            }).catch(err => {
-              if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/latest',
-                sha: context.sha
-              });
-            })
-
-      - name: Create/update version tag
-        uses: actions/github-script@v7
+          TAG_NAME: latest
+          SHA: ${{ github.sha }}
+      - name: Tag release-candidate
+        uses: ./.github/actions/tag-commit
         with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ inputs.VERSION }}',
-              sha: context.sha
-            }).catch(err => {
-              if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/${{ inputs.VERSION }}',
-                sha: context.sha
-              });
-            })
+          TAG_NAME: release-candidate
+          SHA: ${{ github.sha }}
+      - name: Tag edge
+        uses: ./.github/actions/tag-commit
+        with:
+          TAG_NAME: edge
+          SHA: ${{ github.sha }}
+      - name: Tag version
+        uses: ./.github/actions/tag-commit
+        with:
+          TAG_NAME: ${{ needs.determine_version.outputs.version }}
+          SHA: ${{ github.sha }}
 
   create_release:
     name: "create release"
     needs:
-      - release_app
-      - release_api
+      - determine_version
+      - build_and_push_api
+      - build_and_push_app
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -108,7 +118,52 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: "${{ inputs.VERSION }}"
-          name: "swissgeol-assets v${{ inputs.VERSION }}"
+          tag_name: "${{ needs.determine_version.outputs.version }}"
+          name: "swissgeol-assets v${{ needs.determine_version.outputs.version }}"
           generate_release_notes: true
           make_latest: true
+
+  cleanup:
+    name: "cleanup"
+    needs:
+      - determine_version
+      - create_release
+      - tag_commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup node
+        run: |
+          npm install @octokit/rest
+      - name: Get tags
+        id: get_tags
+        run: |
+          git fetch --tags
+          TAGS=$(printf "%s," $(git tag))
+          TAGS=${TAGS%,}
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+      - name: Remove outdated versions
+        uses: actions/github-script@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}
+          CURRENT_VERSION: ${{ needs.determine_version.outputs.version }}
+          TAGS: ${{ steps.get_tags.outputs.tags }}
+        with:
+          script: |
+            const { findOutdatedVersions, makeVersionTag } = require('./.github/scripts/find-version.js');
+            const { removePackageVersions } = require('./.github/scripts/remove-packages.js');
+
+            const tags = process.env.TAGS.split(',');
+            const outdatedVersions = findOutdatedVersions(tags, process.env.CURRENT_VERSION).map(makeVersionTag);
+            for (const version of outdatedVersions) {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${version}`,
+              });
+            }
+
+            await removePackageVersions(`${process.env.BASE_IMAGE_NAME}-api`, outdatedVersions);
+            await removePackageVersions(`${process.env.BASE_IMAGE_NAME}-app`, outdatedVersions);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
           IMAGE_NAME: ${{ vars.BASE_IMAGE_NAME }}-app
           TAG: latest
           OTHER_TAGS: |
-            type=raw,value=edge
-            type=raw,value=release-candidate
+            type=raw,value=${{ env.IS_EDGE == 'true' && 'edge' || '' }}
+            type=raw,value=${{ env.IS_RC == 'true' && 'release-candidate' || '' }}
           VERSION: ${{ needs.determine_version.outputs.version }}
           DOCKERFILE: ./apps/client-asset-sg/docker/Dockerfile
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/client-asset-sg/docker/Dockerfile
+++ b/apps/client-asset-sg/docker/Dockerfile
@@ -1,16 +1,22 @@
+ARG APP_VERSION
+
 FROM node:20-alpine as app-builder
+
+ENV APP_VERSION=${APP_VERSION}
+ENV CYPRESS_INSTALL_BINARY=0
+
+RUN apk add python3 make gcc g++
 
 WORKDIR /app
 COPY . .
-
-ENV CYPRESS_INSTALL_BINARY=0
-RUN apk add python3 make gcc g++
 
 RUN npm install
 RUN npx nx build client-asset-sg --configuration=production
 
 # final image build
 FROM nginx:mainline-alpine
+
+ENV APP_VERSION=${APP_VERSION}
 
 WORKDIR /usr/share/nginx/html
 COPY --from=app-builder /app/dist/apps/client-asset-sg .

--- a/apps/server-asset-sg/docker/Dockerfile
+++ b/apps/server-asset-sg/docker/Dockerfile
@@ -1,17 +1,20 @@
+ARG APP_VERSION
+
 FROM node:20-alpine as api-builder
 
+ENV APP_VERSION=${APP_VERSION}
 ENV NODE_ENV=development
 
 WORKDIR /app
 COPY . .
 
-RUN npm install
-RUN ./node_modules/.bin/prisma generate
+RUN npm install && ./node_modules/.bin/prisma generate
 RUN npx nx build server-asset-sg --configuration=production
 
 # final image build
 FROM node:20-alpine
 
+ENV APP_VERSION=${APP_VERSION}
 ENV NODE_ENV=production
 
 WORKDIR /app

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -128,33 +128,11 @@ services:
     environment:
       CLIENTS_CONFIGURATION_PATH: /tmp/config/clients-config.json
       USERS_CONFIGURATION_PATH: /tmp/config/users-config.json
-      API_SCOPES_INLINE: |
-        [
-            {
-                "Name": "cognito",
-                "UserClaims": [
-                    "cognito:groups",
-                    "username"
-                ]
-            }
-        ]
-      SERVER_OPTIONS_INLINE: |
-        {
-            "IssuerUri": "http://localhost:4011",
-            "AccessTokenJwtType": "JWT",
-            "Discovery": {
-                "ShowKeySet": true
-            },
-            "Authentication": {
-                "CookieSameSiteMode": "Lax",
-                "CheckSessionCookieSameSiteMode": "Lax"
-            },
-            "KeyManagement": {
-              "Enabled": true,
-              "KeyPath": "/tmp/data/keys"
-            }
-        }
+      API_SCOPES_PATH: /tmp/config/scopes-config.json
+      SERVER_OPTIONS_PATH: /tmp/config/server_options-config.json
     volumes:
       - ./init/oidc/oidc-mock-clients.json:/tmp/config/clients-config.json:ro
       - ./init/oidc/oidc-mock-users.json:/tmp/config/users-config.json:ro
+      - ./init/oidc/oidc-mock-scopes.json:/tmp/config/scopes-config.json:ro
+      - ./init/oidc/oidc-mock-server_options.json:/tmp/config/server_options-config.json:ro
       - ./volumes/oidc/keys:/tmp/data/keys

--- a/development/init/oidc/oidc-mock-scopes.json
+++ b/development/init/oidc/oidc-mock-scopes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Name": "cognito",
+    "UserClaims": ["cognito:groups", "username"]
+  }
+]

--- a/development/init/oidc/oidc-mock-server_options.json
+++ b/development/init/oidc/oidc-mock-server_options.json
@@ -1,0 +1,15 @@
+{
+  "IssuerUri": "http://localhost:4011",
+  "AccessTokenJwtType": "JWT",
+  "Discovery": {
+    "ShowKeySet": true
+  },
+  "Authentication": {
+    "CookieSameSiteMode": "Lax",
+    "CheckSessionCookieSameSiteMode": "Lax"
+  },
+  "KeyManagement": {
+    "Enabled": true,
+    "KeyPath": "/tmp/data/keys"
+  }
+}


### PR DESCRIPTION
Resolves #123.
Depends on #137.

**New Workflows**
Updates all current workflows to be aligned closer to boreholes' DevOps suite.

- `CodeQL` remains as is.
- `Code Quality` runs whenever a Pull Request is created or changed. It ensures that the code within the PR is up to standard and fully operational.
- `Publish Edge` runs whenever `develop` is pushed to. It builds a new Docker image for both `app` and `api` and tags it with `edge`. It also generates a development version tag based formatted like `X.X.X-devX`, which ensures that the image is addressable even if `edge` is moved to a newer image.
- `Publish Release Candidate` runs whenever `main` is pushed to. It adds the `release-candidate` tag to the current `edge` images.
- `Relase` has to be run manually. It builds release versions of the current `release-candidate` images, and tags it with a new release version formatted like `X.X.X`. It also adds the tags `edge`, `release-candidate` and `latest` to these images. It then removes any now-outdated tags and images.

`Publish Edge` and `Publish Release Candidate` may also be started manually. This allows for more fine-grained releases, which can be helpful for hotfixes and cross-version jumps.

**Version in Images**
The images built by the workflows now contain the `APP_VERSION`, which holds the application's version number (e.g. `1.2.3-dev4`).


### Please add the label `1.0.0` to the current `main` branch before merging this.
The workflows require a previous version to be present in order to be able to generate the new one.
