### PR TITLE
Feature 138: Filter "Keine Sprache" bei Suchfiltern

### DIFF
--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -27,7 +27,7 @@ export const deAppTranslations = {
     userManagement: 'Benutzer Verwaltung',
   },
   map: {
-    zoomIn: 'Hineinoomen',
+    zoomIn: 'Hineinzoomen',
     zoomOut: 'Herauszoomen',
     zoomToOrigin: 'Zur Ursprungsposition zoomen',
     drawingModeOn: 'Der Zeichenmodus ist ausgeschaltet. Klicken Sie, um den Zeichenmodus einzuschalten',

--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -50,7 +50,6 @@ export const deAppTranslations = {
     originalTitle: 'Originaltitel',
     kind: 'Art',
     topic: 'Thema',
-    language: 'Sprache',
     format: 'Format',
     createdDate: 'Erstellungsdatum',
     lastProcessedDate: 'Letztes Update',
@@ -73,6 +72,10 @@ export const deAppTranslations = {
       LineString: 'Linie',
       Polygon: 'Polygon',
       None: 'Keine',
+    },
+    language: 'Sprache',
+    languageItem: {
+      None: 'keine',
     },
     resetSearch: 'Suche zurücksetzen',
     file: 'Datei',

--- a/apps/client-asset-sg/src/app/i18n/en.ts
+++ b/apps/client-asset-sg/src/app/i18n/en.ts
@@ -51,7 +51,6 @@ export const enAppTranslations: AppTranslations = {
     originalTitle: 'Original title',
     kind: 'Kind',
     topic: 'Topic',
-    language: 'Language',
     format: 'Format',
     createdDate: 'Date created',
     lastProcessedDate: 'Last update',
@@ -74,6 +73,10 @@ export const enAppTranslations: AppTranslations = {
       LineString: 'Line',
       Polygon: 'Polygon',
       None: 'None',
+    },
+    language: 'Language',
+    languageItem: {
+      None: 'none',
     },
     resetSearch: 'Reset search',
     file: 'File',

--- a/apps/client-asset-sg/src/app/i18n/fr.ts
+++ b/apps/client-asset-sg/src/app/i18n/fr.ts
@@ -51,7 +51,6 @@ export const frAppTranslations: AppTranslations = {
     originalTitle: 'Titre original',
     kind: 'Type',
     topic: 'Thème',
-    language: 'Langue',
     format: 'Format',
     createdDate: 'Date de création',
     lastProcessedDate: 'Dernière mise à jour',
@@ -74,6 +73,10 @@ export const frAppTranslations: AppTranslations = {
       LineString: 'Ligne',
       Polygon: 'Polygone',
       None: 'Aucune',
+    },
+    language: 'Langue',
+    languageItem: {
+      None: 'aucune',
     },
     resetSearch: 'Réinitialiser la recherche',
     file: 'Fichier',

--- a/apps/client-asset-sg/src/app/i18n/it.ts
+++ b/apps/client-asset-sg/src/app/i18n/it.ts
@@ -51,7 +51,6 @@ export const itAppTranslations: AppTranslations = {
     originalTitle: 'IT Originaltitel',
     kind: 'IT Art',
     topic: 'IT Thema',
-    language: 'IT Sprache',
     format: 'IT Format',
     createdDate: 'IT Erstellungsdatum',
     lastProcessedDate: 'IT Letztes Update',
@@ -74,6 +73,10 @@ export const itAppTranslations: AppTranslations = {
       LineString: 'IT Linie',
       Polygon: 'IT Polygon',
       None: 'IT Keine',
+    },
+    language: 'IT Sprache',
+    languageItem: {
+      None: 'IT keine',
     },
     resetSearch: 'IT Suche zurücksetzen',
     file: 'IT Datei',

--- a/apps/client-asset-sg/src/app/i18n/rm.ts
+++ b/apps/client-asset-sg/src/app/i18n/rm.ts
@@ -51,7 +51,6 @@ export const rmAppTranslations: AppTranslations = {
     originalTitle: 'RM Originaltitel',
     kind: 'RM Art',
     topic: 'RM Thema',
-    language: 'RM Sprache',
     format: 'RM Format',
     createdDate: 'RM Erstellungsdatum',
     lastProcessedDate: 'RM Letztes Update',
@@ -74,6 +73,10 @@ export const rmAppTranslations: AppTranslations = {
       LineString: 'RM Linie',
       Polygon: 'RM Polygon',
       None: 'RM Keine',
+    },
+    language: 'RM Sprache',
+    languageItem: {
+      None: 'RM keine',
     },
     resetSearch: 'RM Suche zurücksetzen',
     file: 'RM Datei',

--- a/apps/server-asset-sg/jest.config.ts
+++ b/apps/server-asset-sg/jest.config.ts
@@ -15,7 +15,6 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/apps/server-asset-sg',
-  coverageReporters: ['json', 'text', 'cobertura', 'lcov'],
 
   // Allow only a single worker so the tests don't run in parallel.
   // Many of the tests are integration tests, meaning they access actual databases.

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.spec.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.spec.ts
@@ -74,11 +74,14 @@ describe(AssetSearchService, () => {
     expect(hit.sgsId).toEqual(asset.sgsId);
     expect(hit.createDate).toEqual(asset.createDate);
     expect(hit.assetKindItemCode).toEqual(asset.assetKindItemCode);
-    expect(hit.languageItemCodes).toEqual(asset.assetLanguages.map((it) => it.languageItemCode));
     expect(hit.usageCode).toEqual(makeUsageCode(asset.publicUse.isAvailable, asset.internalUse.isAvailable));
     expect(hit.authorIds).toEqual([]);
     expect(hit.contactNames).toEqual([]);
     expect(hit.manCatLabelItemCodes).toEqual([]);
+
+    const languageItemCodes =
+      asset.assetLanguages.length === 0 ? ['None'] : asset.assetLanguages.map((it) => it.languageItemCode);
+    expect(hit.languageItemCodes).toEqual(languageItemCodes);
   };
 
   describe('register', () => {
@@ -355,10 +358,17 @@ describe(AssetSearchService, () => {
         },
       ]);
       expect(stats.languageItemCodes).toEqual(
-        asset.assetLanguages.map((it) => ({
-          value: it.languageItemCode,
-          count: 1,
-        }))
+        asset.assetLanguages.length === 0
+          ? [
+              {
+                count: 1,
+                value: 'None',
+              },
+            ]
+          : asset.assetLanguages.map((it) => ({
+              value: it.languageItemCode,
+              count: 1,
+            }))
       );
       expect(stats.usageCodes).toEqual([
         {
@@ -539,6 +549,13 @@ describe(AssetSearchService, () => {
       const expectedLanguageItemCodes = makeBucket(expectedAssets, (asset) =>
         asset.assetLanguages.map((it) => it.languageItemCode)
       );
+      const assetsWithoutLanguage = expectedAssets.filter((it) => it.assetLanguages.length === 0);
+      if (assetsWithoutLanguage.length !== 0) {
+        expectedLanguageItemCodes.push({
+          key: 'None',
+          count: assetsWithoutLanguage.length,
+        });
+      }
       expect(aggs.buckets.languageItemCodes.sort(compareBuckets)).toEqual(
         expectedLanguageItemCodes.sort(compareBuckets)
       );

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -587,6 +587,8 @@ export class AssetSearchService {
             throw new Error(`unknown geomText prefix: ${prefix}`);
         }
       });
+    const languageItemCodes =
+      asset.assetLanguages.length === 0 ? ['None'] : asset.assetLanguages.map((it) => it.languageItemCode);
     return {
       assetId: asset.assetId,
       titlePublic: asset.titlePublic,
@@ -594,7 +596,7 @@ export class AssetSearchService {
       sgsId: asset.sgsId,
       createDate: asset.createDate,
       assetKindItemCode: asset.assetKindItemCode,
-      languageItemCodes: asset.assetLanguages.map((it) => it.languageItemCode),
+      languageItemCodes,
       usageCode: makeUsageCode(asset.publicUse.isAvailable, asset.internalUse.isAvailable),
       authorIds: asset.assetContacts.filter((it) => it.role === 'author').map((it) => it.contactId),
       contactNames: contacts.map((it) => it.name),

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -655,8 +655,8 @@ const mapQueryToElasticDsl = (query: AssetSearchQuery): QueryDslQueryContainer =
   if (query.languageItemCodes != null) {
     filters.push(makeArrayFilter('languageItemCodes', query.languageItemCodes));
   }
-  if (query.geomCodes != null) {
-    filters.push(makeArrayFilter('geometryCodes', query.geomCodes));
+  if (query.geometryCodes != null) {
+    filters.push(makeArrayFilter('geometryCodes', query.geometryCodes));
   }
 
   return {

--- a/libs/asset-viewer/src/lib/asset-viewer.module.ts
+++ b/libs/asset-viewer/src/lib/asset-viewer.module.ts
@@ -1,3 +1,4 @@
+import { CdkMonitorFocus } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -14,12 +15,13 @@ import {
   AnchorComponent,
   AnimateNumberComponent,
   ButtonComponent,
-  DatePipe,
   DatepickerToggleIconComponent,
+  DatePipe,
   DragHandleComponent,
   DrawerComponent,
   DrawerPanelComponent,
   IsEditorPipe,
+  SmartTranslatePipe,
   ValueItemDescriptionPipe,
   ValueItemNamePipe,
   ZoomControlsComponent,
@@ -27,7 +29,7 @@ import {
 import { SvgIconComponent } from '@ngneat/svg-icon';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
 import { ForModule } from '@rx-angular/template/for';
 import { LetModule } from '@rx-angular/template/let';
 import { PushModule } from '@rx-angular/template/push';
@@ -35,6 +37,7 @@ import { de } from 'date-fns/locale/de';
 
 import { AssetPickerComponent } from './components/asset-picker';
 import { AssetSearchDetailComponent } from './components/asset-search-detail';
+import { AssetSearchFilterListComponent } from './components/asset-search-filter-list/asset-search-filter-list.component';
 import { AssetSearchRefineComponent } from './components/asset-search-refine';
 import { AssetSearchResultsComponent } from './components/asset-search-results';
 import { AssetSearchResultComponent } from './components/asset-search-results/asset-search-result/asset-search-result.component';
@@ -49,6 +52,7 @@ import { assetSearchReducer } from './state/asset-search/asset-search.reducer';
     MapComponent,
     AssetSearchDetailComponent,
     AssetSearchRefineComponent,
+    AssetSearchFilterListComponent,
     AssetSearchResultsComponent,
     AssetPickerComponent,
     AssetSearchResultComponent,
@@ -93,8 +97,11 @@ import { assetSearchReducer } from './state/asset-search/asset-search.reducer';
     DrawerComponent,
     DrawerPanelComponent,
     DatepickerToggleIconComponent,
+    SmartTranslatePipe,
+    CdkMonitorFocus,
   ],
   providers: [
+    TranslatePipe,
     { provide: MAT_DATE_LOCALE, useValue: de },
     {
       provide: MAT_DATE_FORMATS,

--- a/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.html
@@ -1,0 +1,7 @@
+<ul>
+  <li *rxFor="let filter of filters; trackBy: 'value'">
+    <button [disabled]="filter.count === 0" [class.active]="filter.isActive" (click)="toggle(filter)">
+      {{ filter.name | smartTranslate }} ({{ filter.count }})
+    </button>
+  </li>
+</ul>

--- a/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.scss
+++ b/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.scss
@@ -1,23 +1,25 @@
+@use "../../styles/variables";
+
 ul {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
   margin: 1rem 0 0 0;
   padding: 0 0 1rem 0;
-  border-bottom: 2px solid #dee2e6;
+  border-bottom: 2px solid variables.$grey-03;
   list-style: none;
 }
 
 button {
-  background-color: #dee2e6;
+  background-color: variables.$grey-03;
   color: #212429;
   padding: 0.5rem;
   font-size: 0.875rem;
   text-align: left;
 
   &.active {
-    background-color: #b9271a;
-    color: #fff;
+    background-color: variables.$dark-red;
+    color: variables.$white;
   }
 
   &[disabled] {

--- a/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.scss
+++ b/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.scss
@@ -1,0 +1,26 @@
+ul {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 0 0;
+  padding: 0 0 1rem 0;
+  border-bottom: 2px solid #dee2e6;
+  list-style: none;
+}
+
+button {
+  background-color: #dee2e6;
+  color: #212429;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  text-align: left;
+
+  &.active {
+    background-color: #b9271a;
+    color: #fff;
+  }
+
+  &[disabled] {
+    color: #868e96;
+  }
+}

--- a/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-search-filter-list/asset-search-filter-list.component.ts
@@ -1,0 +1,31 @@
+import { Component, inject, Input } from '@angular/core';
+import { Store } from '@ngrx/store';
+import * as actions from '../../state/asset-search/asset-search.actions';
+import { AppStateWithAssetSearch } from '../../state/asset-search/asset-search.reducer';
+import { Filter } from '../../state/asset-search/asset-search.selector';
+
+@Component({
+  selector: 'asset-sg-asset-search-filter-list',
+  templateUrl: './asset-search-filter-list.component.html',
+  styleUrl: './asset-search-filter-list.component.scss',
+})
+export class AssetSearchFilterListComponent<T extends string> {
+  @Input({ required: true })
+  filters!: Array<Filter<T>>;
+
+  private readonly store = inject(Store<AppStateWithAssetSearch>);
+
+  toggle(filter: Filter<T>): void {
+    const activeValues = new Set(this.filters.filter((it) => it.isActive).map((it) => it.value));
+    if (activeValues.has(filter.value)) {
+      activeValues.delete(filter.value);
+    } else {
+      activeValues.add(filter.value);
+    }
+    this.store.dispatch(
+      actions.searchByFilterConfiguration({
+        filterConfiguration: { [filter.queryKey]: [...activeValues] },
+      })
+    );
+  }
+}

--- a/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.html
@@ -1,160 +1,121 @@
-<div class="header" translate="search.searchControl"></div>
+<h2 translate>search.searchControl</h2>
 
 <div class="scrollable-area">
   <div class="search-control-wrapper">
     <button asset-sg-primary translate (click)="resetSearch()">search.resetSearch</button>
-    <button asset-sg-primary *ngIf="(assetSearchQuery$ | push).polygon" (click)="removePolygon()" translate>
+    <button asset-sg-primary *ngIf="assetSearchQuery.polygon" (click)="removePolygon()" translate>
       search.removePolygon
     </button>
   </div>
-  <div class="refine-header" translate="search.refineSearch"></div>
-  <h4 translate>search.usage</h4>
-  <div class="filter-group">
-    <div *ngFor="let usageCode of usageCodes">
-      <button
-        [disabled]="usageCode.count === 0"
-        (click)="updateUsageCodes(usageCode)"
-        class="filter-button"
-        [ngClass]="{ active: usageCode.isActive, disabled: !usageCode.isAvailable }"
-      >
-        {{ "search.usageCode." + usageCode.value | translate }} ({{ usageCode.count }})
-      </button>
-    </div>
-  </div>
-  <h4 translate>search.geometry</h4>
-  <div class="filter-group">
-    <div *ngFor="let geomCode of availableGeomteryCodes">
-      <button
-        [disabled]="geomCode.count === 0"
-        (click)="updateGeometryCodes(geomCode)"
-        class="filter-button"
-        [ngClass]="{ active: geomCode.isActive, disabled: !geomCode.isAvailable }"
-      >
-        {{ "search.geometryCode." + geomCode.value | translate }} ({{ geomCode.count }})
-      </button>
-    </div>
-  </div>
-  <h4 translate>search.language</h4>
-  <div class="filter-group">
-    <div *ngFor="let language of availableLanguages">
-      <button
-        [disabled]="!language.isAvailable"
-        (click)="updateLanguages(language)"
-        class="filter-button"
-        [ngClass]="{ active: language.isActive, disabled: !language.isAvailable }"
-      >
-        {{ language.displayName }} ({{ language.count }})
-      </button>
-    </div>
-  </div>
-  <h4 translate>search.kind</h4>
-  <div class="filter-group">
-    <div *ngFor="let assetKindItem of availableAssetKindItems">
-      <button
-        [disabled]="!assetKindItem.isAvailable"
-        (click)="updateAssetKindItems(assetKindItem)"
-        class="filter-button"
-        [ngClass]="{ active: assetKindItem.isActive, disabled: !assetKindItem.isAvailable }"
-      >
-        {{ assetKindItem.displayName }} ({{ assetKindItem.count }})
-      </button>
-    </div>
-  </div>
-  <h4 translate>search.topic</h4>
-  <div class="filter-group">
-    <div *ngFor="let manCatLabel of availableManCatLabels">
-      <button
-        [disabled]="!manCatLabel.isAvailable"
-        (click)="updateManCatLabel(manCatLabel)"
-        class="filter-button"
-        [ngClass]="{ active: manCatLabel.isActive, disabled: !manCatLabel.isAvailable }"
-      >
-        {{ manCatLabel.displayName }} ({{ manCatLabel.count }})
-      </button>
-    </div>
-  </div>
-  <h4 translate>search.author</h4>
-  <form>
-    <mat-form-field>
-      <mat-label translate>search.author</mat-label>
-      <input
-        type="text"
-        placeholder="Autor wählen"
-        matInput
-        [formControl]="authorAutoCompleteControl"
-        [matAutocomplete]="auto"
-      />
-      <button
-        class="input-clear-button"
-        asset-sg-icon-button
-        matSuffix
-        cdkMonitorElementFocus
-        (click)="resetAuthorSearch()"
-      >
-        <svg-icon key="close"></svg-icon>
-      </button>
-      <mat-autocomplete #auto="matAutocomplete">
-        <mat-option
-          *ngFor="let author of filteredAuthors"
-          [value]="author.name"
-          (onSelectionChange)="updateAuthor($event, author.contactId)"
+  <section class="filters">
+    <h3 translate>search.refineSearch</h3>
+    <section>
+      <h4 translate>search.usage</h4>
+      <asset-sg-asset-search-filter-list [filters]="usageCodeFilters$ | push" />
+    </section>
+    <section>
+      <h4 translate>search.geometry</h4>
+      <asset-sg-asset-search-filter-list [filters]="geometryCodeFilters$ | push" />
+    </section>
+    <section>
+      <h4 translate>search.language</h4>
+      <asset-sg-asset-search-filter-list [filters]="languageFilters$ | push" />
+    </section>
+    <section>
+      <h4 translate>search.kind</h4>
+      <asset-sg-asset-search-filter-list [filters]="assetKindFilters$ | push" />
+    </section>
+    <section>
+      <h4 translate>search.topic</h4>
+      <asset-sg-asset-search-filter-list [filters]="manCatLabelFilters$ | push" />
+    </section>
+    <section>
+      <h4 translate>search.author</h4>
+      <form>
+        <mat-form-field>
+          <mat-label translate>search.author</mat-label>
+          <input
+            type="text"
+            placeholder="Autor wählen"
+            matInput
+            [formControl]="authorAutoCompleteControl"
+            [matAutocomplete]="auto"
+          />
+          <button
+            class="input-clear-button"
+            asset-sg-icon-button
+            matSuffix
+            cdkMonitorElementFocus
+            (click)="resetAuthorSearch()"
+          >
+            <svg-icon key="close"></svg-icon>
+          </button>
+          <mat-autocomplete #auto="matAutocomplete">
+            <mat-option
+              *ngFor="let author of filteredAuthors"
+              [value]="author.name"
+              (onSelectionChange)="updateAuthor($event, author.contactId)"
+            >
+              {{ author.name }} ({{ author.count }})
+            </mat-option>
+          </mat-autocomplete>
+        </mat-form-field>
+      </form>
+    </section>
+    <section>
+      <h4 translate>search.documentDate</h4>
+      <mat-form-field>
+        <mat-label>Datum von</mat-label>
+        <input
+          matInput
+          cdkMonitorElementFocus
+          type="text"
+          [placeholder]="'datePlaceholder' | translate"
+          [formControl]="minDateControl"
+          [min]="createDateRange?.min"
+          [max]="createDateRange?.max"
+          [matDatepicker]="createDateFromPicker"
+        />
+        <mat-datepicker-toggle matPrefix [for]="createDateFromPicker" cdkMonitorSubtreeFocus>
+          <asset-sg-datepicker-toggle-icon matDatepickerToggleIcon></asset-sg-datepicker-toggle-icon>
+        </mat-datepicker-toggle>
+        <mat-datepicker #createDateFromPicker [startAt]="createDateRange?.min ?? null"></mat-datepicker>
+        <button
+          class="input-clear-button"
+          asset-sg-icon-button
+          matSuffix
+          cdkMonitorElementFocus
+          (click)="resetMinDateRangeSearch()"
         >
-          {{ author.name }} ({{ author.count }})
-        </mat-option>
-      </mat-autocomplete>
-    </mat-form-field>
-  </form>
-  <h4 translate>search.documentDate</h4>
-  <mat-form-field>
-    <mat-label>Datum von</mat-label>
-    <input
-      matInput
-      cdkMonitorElementFocus
-      type="text"
-      [placeholder]="'datePlaceholder' | translate"
-      [formControl]="minDateControl"
-      [min]="createDateRange?.min"
-      [max]="createDateRange?.max"
-      [matDatepicker]="createDateFromPicker"
-    />
-    <mat-datepicker-toggle matPrefix [for]="createDateFromPicker" cdkMonitorSubtreeFocus>
-      <asset-sg-datepicker-toggle-icon matDatepickerToggleIcon></asset-sg-datepicker-toggle-icon>
-    </mat-datepicker-toggle>
-    <mat-datepicker #createDateFromPicker [startAt]="createDateRange?.min ?? null"></mat-datepicker>
-    <button
-      class="input-clear-button"
-      asset-sg-icon-button
-      matSuffix
-      cdkMonitorElementFocus
-      (click)="resetMinDateRangeSearch()"
-    >
-      <svg-icon key="close"></svg-icon>
-    </button>
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label>Datum bis</mat-label>
-    <input
-      matInput
-      cdkMonitorElementFocus
-      type="text"
-      [formControl]="maxDateControl"
-      [placeholder]="'datePlaceholder' | translate"
-      [min]="createDateRange?.min"
-      [max]="createDateRange?.max"
-      [matDatepicker]="createDateToPicker"
-    />
-    <mat-datepicker-toggle matPrefix [for]="createDateToPicker" cdkMonitorSubtreeFocus>
-      <asset-sg-datepicker-toggle-icon matDatepickerToggleIcon></asset-sg-datepicker-toggle-icon>
-    </mat-datepicker-toggle>
-    <mat-datepicker #createDateToPicker [startAt]="createDateRange?.max ?? null"></mat-datepicker>
-    <button
-      class="input-clear-button"
-      asset-sg-icon-button
-      matSuffix
-      cdkMonitorElementFocus
-      (click)="resetMaxDateRangeSearch()"
-    >
-      <svg-icon key="close"></svg-icon>
-    </button>
-  </mat-form-field>
+          <svg-icon key="close"></svg-icon>
+        </button>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Datum bis</mat-label>
+        <input
+          matInput
+          cdkMonitorElementFocus
+          type="text"
+          [formControl]="maxDateControl"
+          [placeholder]="'datePlaceholder' | translate"
+          [min]="createDateRange?.min"
+          [max]="createDateRange?.max"
+          [matDatepicker]="createDateToPicker"
+        />
+        <mat-datepicker-toggle matPrefix [for]="createDateToPicker" cdkMonitorSubtreeFocus>
+          <asset-sg-datepicker-toggle-icon matDatepickerToggleIcon></asset-sg-datepicker-toggle-icon>
+        </mat-datepicker-toggle>
+        <mat-datepicker #createDateToPicker [startAt]="createDateRange?.max ?? null"></mat-datepicker>
+        <button
+          class="input-clear-button"
+          asset-sg-icon-button
+          matSuffix
+          cdkMonitorElementFocus
+          (click)="resetMaxDateRangeSearch()"
+        >
+          <svg-icon key="close"></svg-icon>
+        </button>
+      </mat-form-field>
+    </section>
+  </section>
 </div>

--- a/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.scss
+++ b/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.scss
@@ -22,55 +22,41 @@
 @include drawerPanel.draw-panel-header-underline;
 
 .scrollable-area {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding-top: 0.75rem;
   overflow-y: scroll;
   overflow-x: hidden;
 }
 
 .search-control-wrapper {
-  > * {
-    width: 75%;
-
-    &:not(:last-child) {
-      margin-bottom: 0.5rem;
-    }
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-right: 1rem;
 }
 
-.refine-header {
+h2,
+h3 {
   display: flex;
   align-items: center;
-  margin-top: 2rem;
+  margin: 0;
   border-bottom: 2px solid #dee2e6;
   font-size: 0.875rem;
   font-weight: variables.$font-bold;
-  height: 3rem;
-  margin-bottom: 0.75rem;
+  min-height: 3rem;
 }
 
-.filter-group {
+h4 {
+  margin: 0;
+  line-height: 1rem;
+  margin-block: 0.75rem;
+}
+
+section.filters {
   display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  margin-top: 0.5rem;
-  border-bottom: 2px solid #dee2e6;
-  margin-bottom: 0.75rem;
-  padding-bottom: 1rem;
-
-  .filter-button {
-    background-color: #dee2e6;
-    color: #212429;
-    padding: 0.5rem;
-    font-size: 0.875rem;
-
-    &.active {
-      background-color: #b9271a;
-      color: #fff;
-    }
-
-    &.disabled {
-      color: #868e96;
-    }
-  }
+  flex-direction: column;
 }
 
 .mat-mdc-form-field {
@@ -85,9 +71,4 @@
 
 .input-clear-button {
   color: variables.$cyan-09;
-}
-
-h4 {
-  margin: 0;
-  line-height: 2.5rem;
 }

--- a/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.ts
@@ -1,38 +1,34 @@
-import { AfterViewInit, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { AfterViewInit, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatOptionSelectionChange } from '@angular/material/core';
 import { Router } from '@angular/router';
-import { CURRENT_LANG, LifecycleHooksDirective, fromAppShared } from '@asset-sg/client-shared';
-import { AssetSearchQuery, DateRange, GeometryCode, Lang, UsageCode, getValueItemNameKey } from '@asset-sg/shared';
-import { concatLatestFrom } from '@ngrx/effects';
+import { CURRENT_LANG, fromAppShared } from '@asset-sg/client-shared';
+import { AssetSearchQuery, DateRange } from '@asset-sg/shared';
 import { Store } from '@ngrx/store';
-import { Subscription, map, startWith } from 'rxjs';
+import { map, startWith, Subscription } from 'rxjs';
 
 import * as actions from '../../state/asset-search/asset-search.actions';
 import {
   AvailableAuthor,
-  AvailableItem,
-  AvailableValueCount,
+  Filter,
+  selectAssetKindFilters,
   selectAssetSearchQuery,
-  selectAvailableAssetKindItems,
   selectAvailableAuthors,
-  selectAvailableGeometries,
-  selectAvailableLanguages,
-  selectAvailableManCatLabels,
   selectCreateDate,
-  selectUsageCodeData,
+  selectGeometryFilters,
+  selectLanguageFilters,
+  selectManCatLabelFilters,
+  selectUsageCodeFilters,
 } from '../../state/asset-search/asset-search.selector';
 
 @Component({
   selector: 'asset-sg-asset-search-refine',
   templateUrl: './asset-search-refine.component.html',
   styleUrls: ['./asset-search-refine.component.scss'],
-  hostDirectives: [LifecycleHooksDirective],
 })
 export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewInit {
-  private _currentLang$ = inject(CURRENT_LANG);
-  private store = inject(Store);
-  private router = inject(Router);
+  private readonly store = inject(Store);
+  private readonly router = inject(Router);
 
   public authorAutoCompleteControl = new FormControl('');
   public minDateControl = new FormControl();
@@ -41,21 +37,19 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
   public createDateRange: DateRange | null = null;
   public availableAuthors: AvailableAuthor[] = [];
   public filteredAuthors: AvailableAuthor[] = [];
-  public availableGeomteryCodes: AvailableValueCount<GeometryCode | 'None'>[] = [];
-  public usageCodes: AvailableValueCount<UsageCode>[] = [];
-  public availableManCatLabels: AvailableItem[] = [];
-  public availableLanguages: AvailableItem[] = [];
-  public availableAssetKindItems: AvailableItem[] = [];
   public isPanelOpen = false;
 
-  public readonly assetSearchQuery$ = this.store.select(selectAssetSearchQuery);
+  public assetSearchQuery!: AssetSearchQuery;
+
   private readonly createDateRange$ = this.store.select(selectCreateDate);
   private readonly availableAuthors$ = this.store.select(selectAvailableAuthors);
-  private readonly usageCodes$ = this.store.select(selectUsageCodeData);
-  private readonly availableGeometryCodes$ = this.store.select(selectAvailableGeometries);
-  private readonly availableManCatLabels$ = this.store.select(selectAvailableManCatLabels);
-  private readonly availableLanguages$ = this.store.select(selectAvailableLanguages);
-  private readonly availableAssetKindItems$ = this.store.select(selectAvailableAssetKindItems);
+
+  readonly usageCodeFilters$ = this.store.select(selectUsageCodeFilters);
+  readonly geometryCodeFilters$ = this.store.select(selectGeometryFilters);
+  readonly manCatLabelFilters$ = this.store.select(selectManCatLabelFilters);
+  readonly languageFilters$ = this.store.select(selectLanguageFilters);
+  readonly assetKindFilters$ = this.store.select(selectAssetKindFilters);
+
   private readonly isPanelOpen$ = this.store.select(fromAppShared.selectIsPanelOpen);
   private readonly subscriptions: Subscription = new Subscription();
 
@@ -69,14 +63,14 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
 
   public ngAfterViewInit() {
     this.subscriptions.add(
-      this.minDateControl.valueChanges.pipe().subscribe((value) => {
+      this.minDateControl.valueChanges.subscribe((value) => {
         if (value instanceof Date || value === undefined) {
           this.updateSearch({ createDate: { min: value, max: this.maxDateControl.getRawValue() } });
         }
       })
     );
     this.subscriptions.add(
-      this.maxDateControl.valueChanges.pipe().subscribe((value) => {
+      this.maxDateControl.valueChanges.subscribe((value) => {
         if (value instanceof Date || value === undefined) {
           this.updateSearch({ createDate: { min: this.minDateControl.getRawValue(), max: value } });
         }
@@ -88,70 +82,14 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
     this.store.dispatch(actions.removePolygon());
   }
 
-  public updateManCatLabel(item: AvailableItem) {
-    const availableItem: AvailableItem | undefined = this.availableManCatLabels.find(
-      (element) => element.item.code === item.item.code
-    );
-    if (availableItem !== undefined) {
-      availableItem.isActive = !item.isActive;
+  public toggleFilter<T extends string>(all: Array<Filter<T>>, filter: Filter<T>): void {
+    const activeValues = new Set(all.filter((it) => it.isActive).map((it) => it.value));
+    if (activeValues.has(filter.value)) {
+      activeValues.delete(filter.value);
+    } else {
+      activeValues.add(filter.value);
     }
-    this.updateSearch({
-      manCatLabelItemCodes: this.availableManCatLabels
-        .filter((element) => element.isActive)
-        .map((element) => element.item.code),
-    });
-  }
-
-  public updateAssetKindItems(item: AvailableItem) {
-    const availableItem: AvailableItem | undefined = this.availableAssetKindItems.find(
-      (element) => element.item.code === item.item.code
-    );
-    if (availableItem !== undefined) {
-      availableItem.isActive = !item.isActive;
-    }
-    this.updateSearch({
-      assetKindItemCodes: this.availableAssetKindItems
-        .filter((element) => element.isActive)
-        .map((element) => element.item.code),
-    });
-  }
-
-  public updateLanguages(item: AvailableItem) {
-    const availableItem: AvailableItem | undefined = this.availableLanguages.find(
-      (element) => element.item.code === item.item.code
-    );
-    if (availableItem !== undefined) {
-      availableItem.isActive = !item.isActive;
-    }
-    this.updateSearch({
-      languageItemCodes: this.availableLanguages
-        .filter((element) => element.isActive)
-        .map((element) => element.item.code),
-    });
-  }
-
-  public updateUsageCodes(item: AvailableValueCount<UsageCode>) {
-    const availableItem: AvailableValueCount<UsageCode> | undefined = this.usageCodes.find(
-      (element) => element.value === item.value
-    );
-    if (availableItem !== undefined) {
-      availableItem.isActive = !item.isActive;
-    }
-    this.updateSearch({
-      usageCodes: this.usageCodes.filter((element) => element.isActive).map((element) => element.value),
-    });
-  }
-
-  public updateGeometryCodes(item: AvailableValueCount<GeometryCode | 'None'>) {
-    const availableItem: AvailableValueCount<GeometryCode | 'None'> | undefined = this.availableGeomteryCodes.find(
-      (element) => element.value === item.value
-    );
-    if (availableItem !== undefined) {
-      availableItem.isActive = !item.isActive;
-    }
-    this.updateSearch({
-      geomCodes: this.availableGeomteryCodes.filter((element) => element.isActive).map((element) => element.value),
-    });
+    this.updateSearch({ [filter.queryKey]: [...activeValues] });
   }
 
   public updateAuthor(event: MatOptionSelectionChange, authorId: number) {
@@ -185,7 +123,7 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
   }
 
   public resetSearch() {
-    this.router.navigate([]);
+    void this.router.navigate([]);
     this.authorAutoCompleteControl.setValue('');
     this.maxDateControl.setValue(null);
     this.maxDateControl.setValue(null);
@@ -194,6 +132,12 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
 
   private initSubscriptions() {
     this.subscriptions.add(this.isPanelOpen$.subscribe((isOpen) => (this.isPanelOpen = isOpen)));
+
+    this.subscriptions.add(
+      this.store.select(selectAssetSearchQuery).subscribe((query) => {
+        this.assetSearchQuery = query;
+      })
+    );
 
     this.subscriptions.add(
       this.createDateRange$.subscribe((dateRange) => {
@@ -209,51 +153,6 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
     );
 
     this.subscriptions.add(
-      this.usageCodes$.subscribe((usageCodes) => {
-        this.usageCodes = usageCodes ?? [];
-      })
-    );
-
-    this.subscriptions.add(
-      this.availableGeometryCodes$.subscribe((geomCode) => {
-        this.availableGeomteryCodes = geomCode ?? [];
-      })
-    );
-
-    this.subscriptions.add(
-      this.availableManCatLabels$
-        .pipe(
-          concatLatestFrom(() => this._currentLang$),
-          map(([manCatLabels, lang]) => {
-            this.availableManCatLabels = this.setLanguageForFilter(lang, manCatLabels ?? []);
-          })
-        )
-        .subscribe()
-    );
-
-    this.subscriptions.add(
-      this.availableLanguages$
-        .pipe(
-          concatLatestFrom(() => this._currentLang$),
-          map(([languages, currentLang]) => {
-            this.availableLanguages = this.setLanguageForFilter(currentLang, languages ?? []);
-          })
-        )
-        .subscribe()
-    );
-
-    this.subscriptions.add(
-      this.availableAssetKindItems$
-        .pipe(
-          concatLatestFrom(() => this._currentLang$),
-          map(([assetKindItems, currentLang]) => {
-            this.availableAssetKindItems = this.setLanguageForFilter(currentLang, assetKindItems ?? []);
-          })
-        )
-        .subscribe()
-    );
-
-    this.subscriptions.add(
       this.authorAutoCompleteControl.valueChanges
         .pipe(
           startWith(''),
@@ -263,24 +162,5 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
           this.filteredAuthors = filteredAuthors;
         })
     );
-
-    this.subscriptions.add(
-      this._currentLang$.subscribe((lang) => {
-        this.availableAssetKindItems = this.setLanguageForFilter(lang, this.availableAssetKindItems);
-        this.availableLanguages = this.setLanguageForFilter(lang, this.availableLanguages);
-        this.availableManCatLabels = this.setLanguageForFilter(lang, this.availableManCatLabels);
-      })
-    );
-  }
-
-  private setLanguageForFilter(lang: Lang, availableFilters: AvailableItem[]): AvailableItem[] {
-    const key = getValueItemNameKey(lang);
-    const filtersWithDisplayName = availableFilters.map((filter) => {
-      return {
-        ...filter,
-        displayName: filter.item[key],
-      };
-    });
-    return filtersWithDisplayName.sort((a, b) => a.displayName.localeCompare(b.displayName));
   }
 }

--- a/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-search-refine/asset-search-refine.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, inject, OnDestroy, OnInit } from '@angular/co
 import { FormControl } from '@angular/forms';
 import { MatOptionSelectionChange } from '@angular/material/core';
 import { Router } from '@angular/router';
-import { CURRENT_LANG, fromAppShared } from '@asset-sg/client-shared';
+import { fromAppShared } from '@asset-sg/client-shared';
 import { AssetSearchQuery, DateRange } from '@asset-sg/shared';
 import { Store } from '@ngrx/store';
 import { map, startWith, Subscription } from 'rxjs';
@@ -10,7 +10,6 @@ import { map, startWith, Subscription } from 'rxjs';
 import * as actions from '../../state/asset-search/asset-search.actions';
 import {
   AvailableAuthor,
-  Filter,
   selectAssetKindFilters,
   selectAssetSearchQuery,
   selectAvailableAuthors,
@@ -80,16 +79,6 @@ export class AssetSearchRefineComponent implements OnInit, OnDestroy, AfterViewI
 
   public removePolygon() {
     this.store.dispatch(actions.removePolygon());
-  }
-
-  public toggleFilter<T extends string>(all: Array<Filter<T>>, filter: Filter<T>): void {
-    const activeValues = new Set(all.filter((it) => it.isActive).map((it) => it.value));
-    if (activeValues.has(filter.value)) {
-      activeValues.delete(filter.value);
-    } else {
-      activeValues.add(filter.value);
-    }
-    this.updateSearch({ [filter.queryKey]: [...activeValues] });
   }
 
   public updateAuthor(event: MatOptionSelectionChange, authorId: number) {

--- a/libs/asset-viewer/src/lib/components/asset-viewer-page/asset-viewer-page.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-viewer-page/asset-viewer-page.component.ts
@@ -99,7 +99,7 @@ export class AssetViewerPageComponent implements OnDestroy {
   public highlightAssetStudies$ = new Subject<O.Option<number>>();
 
   public ngAfterViewInit() {
-    this._store.dispatch(actions.readParams());
+    this._store.dispatch(actions.initializeSearch());
     this._appPortalService.setAppBarPortalContent(null);
   }
 

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.actions.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.actions.ts
@@ -24,7 +24,7 @@ export const updateSearchResults = createAction(
 export const clearSearchText = createAction('[Asset Search] Clear search text');
 export const resetSearch = createAction('[Asset Search] Reset Search');
 export const removePolygon = createAction('[Asset Search] Remove polygon');
-export const readParams = createAction('[Asset Search] Read Params');
+export const initializeSearch = createAction('[Asset Search] Initialize search');
 export const setLoadingState = createAction('[Asset Search] Set loading state');
 export const searchForAssetDetail = createAction(
   '[Asset Search] Search for asset detail',

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.effects.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.effects.ts
@@ -41,7 +41,7 @@ export class AssetSearchEffects {
   // noinspection JSUnusedGlobalSymbols
   readSearchQueryParams$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(actions.readParams),
+      ofType(actions.initializeSearch),
       concatLatestFrom(() => this.route.queryParams),
       map(([_, params]) => {
         const query: AssetSearchQuery = {};
@@ -55,7 +55,7 @@ export class AssetSearchEffects {
         query.manCatLabelItemCodes = readArrayParam(params, QUERY_PARAM_MAPPING.manCatLabelItemCodes);
         query.assetKindItemCodes = readArrayParam(params, QUERY_PARAM_MAPPING.assetKindItemCodes);
         query.usageCodes = readArrayParam(params, QUERY_PARAM_MAPPING.usageCodes);
-        query.geomCodes = readArrayParam(params, QUERY_PARAM_MAPPING.geomCodes);
+        query.geometryCodes = readArrayParam(params, QUERY_PARAM_MAPPING.geometryCodes);
         query.languageItemCodes = readArrayParam(params, QUERY_PARAM_MAPPING.languageItemCodes);
         return { query, assetId };
       }),
@@ -64,9 +64,16 @@ export class AssetSearchEffects {
     )
   );
 
+  getStatsOnInitialize$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(actions.initializeSearch),
+      map(() => actions.getStats())
+    )
+  );
+
   readAssetIdQueryParam$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(actions.readParams),
+      ofType(actions.initializeSearch),
       concatLatestFrom(() => this.route.queryParams),
       map(([_, params]) => readNumberParam(params, QUERY_PARAM_MAPPING.assetId)),
       filter((assetId): assetId is number => assetId !== undefined),
@@ -95,7 +102,7 @@ export class AssetSearchEffects {
           updateArrayParam(params, QUERY_PARAM_MAPPING.manCatLabelItemCodes, query.manCatLabelItemCodes);
           updateArrayParam(params, QUERY_PARAM_MAPPING.assetKindItemCodes, query.assetKindItemCodes);
           updateArrayParam(params, QUERY_PARAM_MAPPING.usageCodes, query.usageCodes);
-          updateArrayParam(params, QUERY_PARAM_MAPPING.geomCodes, query.geomCodes);
+          updateArrayParam(params, QUERY_PARAM_MAPPING.geometryCodes, query.geometryCodes);
           updateArrayParam(params, QUERY_PARAM_MAPPING.languageItemCodes, query.languageItemCodes);
           this.router.navigate([], {
             queryParams: params,
@@ -207,7 +214,7 @@ const QUERY_PARAM_MAPPING = {
   manCatLabelItemCodes: 'search[manCat]',
   assetKindItemCodes: 'search[kind]',
   usageCodes: 'search[usage]',
-  geomCodes: 'search[geom]',
+  geometryCodes: 'search[geometry]',
   languageItemCodes: 'search[lang]',
   assetId: 'assetId',
 };

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.reducer.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.reducer.ts
@@ -36,7 +36,7 @@ const initialState: AssetSearchState = {
     manCatLabelItemCodes: undefined,
     assetKindItemCodes: undefined,
     usageCodes: undefined,
-    geomCodes: undefined,
+    geometryCodes: undefined,
     languageItemCodes: undefined,
   },
   results: {

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
@@ -1,5 +1,5 @@
 import { formatNumber } from '@angular/common';
-import { fromAppShared } from '@asset-sg/client-shared';
+import { fromAppShared, TranslatedValue, Translation } from '@asset-sg/client-shared';
 import {
   AssetEditDetail,
   Contact,
@@ -7,15 +7,17 @@ import {
   GeometryCode,
   LineString,
   LV95,
-  ordStatusWorkByDate,
   Point,
   ReferenceData,
   Study,
   StudyPolygon,
   UsageCode,
-  usageCodes,
   ValueCount,
   ValueItem,
+  AssetSearchQuery,
+  AssetSearchStats,
+  usageCodes,
+  ordStatusWorkByDate,
 } from '@asset-sg/shared';
 import * as RD from '@devexperts/remote-data-ts';
 import { createSelector } from '@ngrx/store';
@@ -143,102 +145,104 @@ export const selectAvailableAuthors = createSelector(
 
 export const selectCreateDate = createSelector(selectAssetsSearchStats, (stats): DateRange | null => stats.createDate);
 
-export const selectUsageCodeData = createSelector(
-  selectAssetsSearchStats,
-  selectAssetSearchQuery,
-  (stats, query): AvailableValueCount<UsageCode>[] => {
-    return usageCodes.map((usageCode) => {
-      const count = stats.usageCodes.find((item) => item.value === usageCode)?.count ?? 0;
-      return {
-        value: usageCode,
-        count,
-        isAvailable: count > 0,
-        isActive: count > 0 && (query.usageCodes?.includes(usageCode) ?? true),
-      };
-    });
-  }
-);
+const makeFilters = <T extends string>(
+  configs: Array<FilterConfig<T>>,
+  counts: Array<ValueCount<T>>,
+  activeValues: T[] | undefined,
+  queryKey: keyof AssetSearchQuery
+): Array<Filter<T>> => {
+  return configs.map((filter) => makeFilter(filter, activeValues, counts, queryKey));
+};
 
-export const selectAvailableAssetKindItems = createSelector(
-  fromAppShared.selectRDReferenceData,
-  selectAssetsSearchStats,
-  selectAssetSearchQuery,
-  (referenceData, stats, query): AvailableItem[] | null => {
-    if (RD.isSuccess(referenceData)) {
-      const assetKindItems: ValueItem[] = Object.values(referenceData.value.assetKindItems);
-      return assetKindItems.flatMap((assetKindItem): AvailableItem => {
-        const count = stats.assetKindItemCodes.find((item) => item.value === assetKindItem.code)?.count ?? 0;
-        return {
-          item: assetKindItem,
-          count,
-          isAvailable: count > 0,
-          isActive: count > 0 && (query.assetKindItemCodes?.includes(assetKindItem.code) ?? true),
-        };
-      });
+const makeFilter = <T extends string>(
+  filter: FilterConfig<T>,
+  activeValues: T[] | undefined,
+  counts: Array<ValueCount<T>>,
+  queryKey: keyof AssetSearchQuery
+): Filter<T> => {
+  const count = counts.find((counter) => counter.value === filter.value)?.count ?? 0;
+  return {
+    ...filter,
+    count,
+    queryKey,
+
+    // For filters to be active, they need to have at least one asset that they apply to.
+    // Also, if there are currently no filters selected (e.g. in the default search state),
+    // then we select all available filters.
+    isActive: count > 0 && (activeValues?.includes(filter.value) ?? true),
+  };
+};
+
+export const selectFilters = <T extends string>(
+  queryKey: keyof AssetSearchQuery & keyof AssetSearchStats,
+  getFilters: (referenceData: ReferenceData) => Array<FilterConfig<T>>
+) =>
+  createSelector(
+    fromAppShared.selectRDReferenceData,
+    selectAssetSearchQuery,
+    selectAssetsSearchStats,
+    (referenceData, query, stats): Array<Filter<T>> => {
+      if (!RD.isSuccess(referenceData)) {
+        return [];
+      }
+      return makeFilters(
+        getFilters(referenceData.value),
+
+        // Note that reading these attributes by key is insecure,
+        // since both the query and the stats have attributes that don't match the types required here.
+        // However, being able to use keys here (instead of functions or anything else)
+        // makes using this selector a lot easier.
+        // Passing invalid keys here is a programmer mistake anyway (which should be caught in testing at the latest),
+        // so leaving it like this should be okay.
+        stats[queryKey] as Array<ValueCount<T>>,
+        query[queryKey] as T[] | undefined,
+
+        queryKey
+      );
     }
-    return null;
-  }
+  );
+
+export const selectUsageCodeFilters = selectFilters<UsageCode>('usageCodes', () =>
+  usageCodes.map((code) => ({
+    name: { key: `search.usageCode.${code}` },
+    value: code,
+  }))
 );
 
-export const selectAvailableLanguages = createSelector(
-  fromAppShared.selectRDReferenceData,
-  selectAssetsSearchStats,
-  selectAssetSearchQuery,
-  (referenceData, stats, query): AvailableItem[] | null => {
-    if (RD.isSuccess(referenceData)) {
-      const languageItems: ValueItem[] = Object.values(referenceData.value.languageItems);
-      return languageItems.map((languageItem) => {
-        const count = stats.languageItemCodes.find((item) => item.value === languageItem.code)?.count ?? 0;
-        return {
-          item: languageItem,
-          count,
-          isAvailable: count > 0,
-          isActive: count > 0 && (query.languageItemCodes?.includes(languageItem.code) ?? true),
-        };
-      });
-    }
-    return null;
-  }
+export const selectAssetKindFilters = selectFilters<string>('assetKindItemCodes', (data) =>
+  Object.values(data.assetKindItems).map((item) => ({
+    name: makeTranslatedValueFromItemName(item),
+    value: item.code,
+  }))
 );
 
-export const selectAvailableGeometries = createSelector(
-  selectAssetsSearchStats,
-  selectAssetSearchQuery,
-  (stats, query): AvailableValueCount<GeometryCode | 'None'>[] | null => {
-    const geometries: Array<GeometryCode | 'None'> = Object.values(GeometryCode);
-    geometries.push('None');
-    const availableGeometries = geometries.map((geometry) => {
-      const count = stats.geometryCodes.find((item) => item.value === geometry)?.count ?? 0;
-      return {
-        value: geometry,
-        count: count,
-        isAvailable: count > 0,
-        isActive: count > 0 && (query.geomCodes?.includes(geometry) ?? true),
-      };
-    });
-    return availableGeometries;
-  }
-);
+export const selectLanguageFilters = selectFilters<string>('languageItemCodes', (data) => [
+  ...Object.values(data.languageItems).map((item) => ({
+    name: makeTranslatedValueFromItemName(item),
+    value: item.code,
+  })),
+  {
+    name: { key: 'search.languageItem.None' },
+    value: 'None',
+  },
+]);
 
-export const selectAvailableManCatLabels = createSelector(
-  fromAppShared.selectRDReferenceData,
-  selectAssetsSearchStats,
-  selectAssetSearchQuery,
-  (referenceData, stats, query): AvailableItem[] | null => {
-    if (RD.isSuccess(referenceData)) {
-      const manCatLabels: ValueItem[] = Object.values(referenceData.value.manCatLabelItems);
-      return manCatLabels.map((manCatLabel) => {
-        const count = stats.manCatLabelItemCodes.find((item) => item.value === manCatLabel.code)?.count ?? 0;
-        return {
-          item: manCatLabel,
-          count,
-          isAvailable: count > 0,
-          isActive: count > 0 && (query.manCatLabelItemCodes?.includes(manCatLabel.code) ?? true),
-        };
-      });
-    }
-    return null;
-  }
+export const selectGeometryFilters = selectFilters<GeometryCode | 'None'>('geometryCodes', () => [
+  ...Object.values(GeometryCode).map((code) => ({
+    name: { key: `search.geometryCode.${code}` },
+    value: code,
+  })),
+  {
+    name: { key: 'search.geometryCode.None' },
+    value: 'None',
+  },
+]);
+
+export const selectManCatLabelFilters = selectFilters<string>('manCatLabelItemCodes', (data) =>
+  Object.values(data.manCatLabelItems).map((item) => ({
+    name: makeTranslatedValueFromItemName(item),
+    value: item.code,
+  }))
 );
 
 export interface AvailableAuthor {
@@ -251,18 +255,37 @@ export interface FullContact extends Contact {
   role?: string;
 }
 
-export interface AvailableItem {
-  item: ValueItem;
+export interface Filter<T extends string = string> {
+  name: Translation;
+  value: T;
+
+  /**
+   * The total number of assets within the current result set
+   * that match this filter.
+   */
   count: number;
-  isAvailable: boolean;
+
+  /**
+   * Whether the filter is currently in effect,
+   * i.e. whether assets that match it are visible.
+   */
   isActive: boolean;
-  displayName?: string;
+
+  /**
+   * The field of {@link AssetSearchQuery} that contains this filter's values.
+   */
+  queryKey: keyof AssetSearchQuery;
 }
 
-export interface AvailableValueCount<T> extends ValueCount<T> {
-  isAvailable: boolean;
-  isActive: boolean;
-}
+type FilterConfig<T extends string> = Pick<Filter<T>, 'name' | 'value'>;
+
+export const makeTranslatedValueFromItemName = (item: ValueItem): TranslatedValue => ({
+  de: item.nameDe,
+  fr: item.nameFr,
+  rm: item.nameRm,
+  it: item.nameIt,
+  en: item.nameEn,
+});
 
 export interface StudyVM extends Study {
   assetId: number;

--- a/libs/client-shared/src/lib/components/index.ts
+++ b/libs/client-shared/src/lib/components/index.ts
@@ -8,3 +8,4 @@ export * from './drawer';
 export * from './ol-zoom-controls';
 export * from './value-item';
 export * from './view-child-marker';
+export * from './smart-translate.pipe';

--- a/libs/client-shared/src/lib/components/smart-translate.pipe.ts
+++ b/libs/client-shared/src/lib/components/smart-translate.pipe.ts
@@ -1,0 +1,58 @@
+import { inject, OnDestroy, Pipe, PipeTransform } from '@angular/core';
+import { Lang } from '@asset-sg/shared';
+import { TranslatePipe } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
+import { CURRENT_LANG } from '../utils';
+
+/**
+ * A pipe that applies a different kind of translation depending on the value passed to it.
+ * - For {@link TranslationKey}s, the key is translated using {@link TranslatePipe translate}.
+ * - For {@link TranslatedValue}s, the value for the current language is used.
+ */
+@Pipe({
+  standalone: true,
+  name: 'smartTranslate',
+  pure: false,
+})
+export class SmartTranslatePipe implements PipeTransform, OnDestroy {
+  private readonly translationPipe = inject(TranslatePipe);
+  private readonly currentLang$ = inject(CURRENT_LANG);
+  private currentLang: Lang = 'de';
+  private readonly subscription = new Subscription();
+
+  constructor() {
+    this.subscription.add(
+      this.currentLang$.subscribe((currentLang) => {
+        this.currentLang = currentLang;
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  transform(value: TranslationKey | TranslatedValue): string {
+    if (isTranslationKey(value)) {
+      return this.translationPipe.transform(value.key);
+    }
+    return value[this.currentLang];
+  }
+}
+
+export type Translation = TranslationKey | TranslatedValue;
+
+export interface TranslationKey {
+  key: string;
+}
+
+export interface TranslatedValue {
+  de: string;
+  fr: string;
+  rm: string;
+  it: string;
+  en: string;
+}
+
+const isTranslationKey = (value: unknown): value is TranslationKey =>
+  typeof value == 'object' && value != null && 'key' in value && typeof value.key === 'string';

--- a/libs/shared/src/lib/models/asset-search/asset-search-query.dto.ts
+++ b/libs/shared/src/lib/models/asset-search/asset-search-query.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsEnum, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { PartialDateRangeDTO } from '../date-range.dto';
 import { UsageCode } from '../usage';
@@ -31,8 +31,8 @@ export class AssetSearchQueryDTO implements AssetSearchQuery {
   usageCodes?: UsageCode[];
 
   @IsOptional()
-  @IsEnum(GeometryCode, { each: true })
-  geomCodes?: Array<GeometryCode | 'None'>;
+  @IsIn([...Object.values(GeometryCode), 'None'], { each: true })
+  geometryCodes?: Array<GeometryCode | 'None'>;
 
   @IsString({ each: true })
   @IsOptional()

--- a/libs/shared/src/lib/models/asset-search/asset-search-query.ts
+++ b/libs/shared/src/lib/models/asset-search/asset-search-query.ts
@@ -10,7 +10,7 @@ export interface AssetSearchQuery {
   manCatLabelItemCodes?: string[];
   assetKindItemCodes?: string[];
   usageCodes?: UsageCode[];
-  geomCodes?: Array<GeometryCode | 'None'>;
+  geometryCodes?: Array<GeometryCode | 'None'>;
   languageItemCodes?: string[];
 }
 


### PR DESCRIPTION
Resolves #138.

Adds the `None` language item to ElasticSearch assets that don't have any languages assigned to them.

Also, the filter selectors of the asset-search state have been refactored so that filters that rely on static values can be used the same as filters that use database values.