### PR TITLE
Fix: Studies missing from map

### DIFF
--- a/libs/asset-viewer/src/lib/services/all-study.service.ts
+++ b/libs/asset-viewer/src/lib/services/all-study.service.ts
@@ -29,7 +29,7 @@ export class AllStudyService {
           studyId: `study_${id}`,
           assetId: parseInt(assetId),
           isPoint: Boolean(isPoint),
-          centroid: { x: parseInt(x), y: parseInt(y) } as LV95,
+          centroid: { x: parseFloat(x), y: parseFloat(y) } as LV95,
         } as AllStudyDTO;
       }),
       toArray(),

--- a/libs/shared/src/lib/models/lv95.ts
+++ b/libs/shared/src/lib/models/lv95.ts
@@ -86,9 +86,9 @@ export const lv95RoundedToMillimeter = (lv95: LV95): LV95 => ({
 });
 
 export const parseLV95 = (value: string, { separator }: { separator: string }): LV95 => {
-  const [x, y] = value.split(separator, 2);
+  const [y, x] = value.split(separator, 2);
   return {
-    x: parseInt(x) as LV95X,
-    y: parseInt(y) as LV95Y,
+    x: parseFloat(x) as LV95X,
+    y: parseFloat(y) as LV95Y,
   };
 };


### PR DESCRIPTION
Fixed studies not being displayed on the map.
The issue was that when parsing the studies' center coordinates from the DB, the x and y coordinates must be switched, which no longer happened in the latest version.