### PR TITLE
Fix: Add missing optional NX dependencies used by docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,9 @@
     "@nx/nx-darwin-x64": "19.2.1",
     "@nx/nx-linux-x64-gnu": "19.2.1",
     "@nx/nx-win32-x64-msvc": "19.2.1",
-    "@rollup/rollup-linux-x64-gnu": "4.16.0"
+    "@nx/nx-linux-x64-musl": "19.2.1",
+    "@rollup/rollup-linux-x64-gnu": "4.16.0",
+    "@rollup/rollup-linux-x64-musl": "4.16.0"
   },
   "prisma": {
     "schema": "apps/server-asset-sg/prisma/schema.prisma"


### PR DESCRIPTION
The `develop` build is missing some NX build dependencies used when building the app's Docker images. This PR adds them.