### PR TITLE
Fix: Pipeline Build

### DIFF
--- a/apps/pipeline-asset-sg/src/core/export-to-view.service.ts
+++ b/apps/pipeline-asset-sg/src/core/export-to-view.service.ts
@@ -235,17 +235,16 @@ export class ExportToViewService {
   }
 
   /**
-   * Export files.
-   * Remove files which start with 'LDoc'
+   * Export non-legal files.
    */
   private async exportFiles(assetIds: number[]) {
     log(`Starting file export.`);
-    // Read all unique file ids from the assetFiles which dont include 'LDoc'
+    // Read all unique file ids from the assetFiles which are not legal docs.
     const assetFiles = await this.sourcePrisma.assetFile.findMany({
-      where: { assetId: { in: assetIds }, file: { fileName: { not: { contains: 'LDoc' } } } },
+      where: { assetId: { in: assetIds }, file: { type: { not: 'Legal' } } },
     });
     const fileIds = [...new Set(assetFiles.map((af) => af.fileId))];
-    const files = await this.sourcePrisma.file.findMany({ where: { fileId: { in: fileIds } } });
+    const files = await this.sourcePrisma.file.findMany({ where: { id: { in: fileIds } } });
 
     // Write files to the destination database
     const fileResult = await this.destinationPrisma.file.createMany({

--- a/libs/persistence/prisma/schema.prisma
+++ b/libs/persistence/prisma/schema.prisma
@@ -2,7 +2,7 @@ generator client {
   provider        = "prisma-client-js"
   output          = "../../../node_modules/.prisma/client"
   previewFeatures = ["views"]
-  binaryTargets   = ["debian-openssl-3.0.x"]
+  binaryTargets   = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:server": "npx nx serve server-asset-sg",
     "start:client": "npx nx serve client-asset-sg",
     "start:pipeline": "npx nx serve pipeline-asset-sg --watch false",
-    "build": "npx nx run-many -t build -p server-asset-sg client-asset-sg --configuration=production",
+    "build": "npx nx run-many -t build -p server-asset-sg client-asset-sg pipeline-asset-sg --configuration=production",
     "build:server": "npx nx build server-asset-sg --configuration=production",
     "build:client": "npx nx build client-asset-sg --configuration=production",
     "prisma": "dotenv -e apps/server-asset-sg/.env -e apps/server-asset-sg/.env.local -- npx prisma",


### PR DESCRIPTION
Remove legal doc distinction in file export - they are now in a separate table

Add `native` to Prisma's `binaryTargets`

Add `pipeline-asset-sg` to the `build` command