### PR TITLE
Hotfix: Docker Builds Failing due to Missing Prisma Source Files

### DIFF
--- a/apps/client-asset-sg/docker/Dockerfile
+++ b/apps/client-asset-sg/docker/Dockerfile
@@ -15,6 +15,7 @@ COPY . .
 
 RUN sed -i ''s/0.0.0-local/${APP_VERSION}/g'' apps/client-asset-sg/src/assets/version.json \
  && npm install --ignore-scripts \
+ && npm run prisma -- generate   \
  && npx nx build client-asset-sg --configuration=production
 
 # final image build

--- a/apps/server-asset-sg/docker/Dockerfile
+++ b/apps/server-asset-sg/docker/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 COPY . .
 
 RUN npm install --ignore-scripts \
+ && npm run prisma -- generate   \
  && npx nx build server-asset-sg --configuration=production
 
 # final image build


### PR DESCRIPTION
Generates prisma source files before compiling in docker builds.