### PR TITLE
Feature/assets 299 add map legend

### DIFF
--- a/libs/asset-viewer/src/lib/asset-viewer.module.ts
+++ b/libs/asset-viewer/src/lib/asset-viewer.module.ts
@@ -60,11 +60,11 @@ import { FileSizePipe } from './components/asset-viewer-files/file-size-display.
 import { AssetViewerPageComponent } from './components/asset-viewer-page';
 import { MapComponent } from './components/map/map.component';
 import { MapControlsComponent } from './components/map-controls/map-controls.component';
+import { MapLegendComponent } from './components/map-legend/map-legend.component';
 import { ViewerParamsService } from './services/viewer-params.service';
 import { AssetSearchEffects } from './state/asset-search/asset-search.effects';
 import { assetSearchReducer } from './state/asset-search/asset-search.reducer';
 import { mapControlReducer } from './state/map-control/map-control.reducer';
-import { MapLegendComponent } from './components/map-legend/map-legend.component';
 
 @NgModule({
   declarations: [

--- a/libs/asset-viewer/src/lib/asset-viewer.module.ts
+++ b/libs/asset-viewer/src/lib/asset-viewer.module.ts
@@ -64,6 +64,7 @@ import { ViewerParamsService } from './services/viewer-params.service';
 import { AssetSearchEffects } from './state/asset-search/asset-search.effects';
 import { assetSearchReducer } from './state/asset-search/asset-search.reducer';
 import { mapControlReducer } from './state/map-control/map-control.reducer';
+import { MapLegendComponent } from './components/map-legend/map-legend.component';
 
 @NgModule({
   declarations: [
@@ -134,6 +135,7 @@ import { mapControlReducer } from './state/map-control/map-control.reducer';
     MatTooltip,
     CanCreateDirective,
     CanUpdateDirective,
+    MapLegendComponent,
   ],
   providers: [
     TranslatePipe,

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
@@ -1,0 +1,29 @@
+<cdk-accordion class="map-legend">
+  <cdk-accordion-item #legend="cdkAccordionItem" class="map-legend__content">
+    <div [attr.aria-expanded]="legend.expanded" [attr.id]="'legend-header'" class="map-legend__content__header">
+      <button (click)="handleChange()" asset-sg-icon-button class="map-legend__content__header__button">
+        <svg-icon [key]="'change'"></svg-icon>
+      </button>
+      <span class="map-legend__content__header__title"> Titel </span>
+      <button
+        (click)="legend.toggle()"
+        [attr.aria-controls]="'legend-body'"
+        asset-sg-icon-button
+        class="map-legend__content__header__button"
+      >
+        <svg-icon [key]="legend.expanded ? 'arrow-up' : 'arrow-down'"></svg-icon>
+      </button>
+    </div>
+    @if (legend.expanded) {
+    <div
+      class="map-legend__content__body"
+      role="region"
+      [style.display]="legend.expanded ? '' : 'none'"
+      [attr.id]="'legend-body'"
+      [attr.aria-labelledby]="'legend-header'"
+    >
+      Content
+    </div>
+    }
+  </cdk-accordion-item>
+</cdk-accordion>

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
@@ -21,7 +21,7 @@
       @for (styleItem of activeStyle.styleItems; track $index) {
       <div class="map-legend__content__body__item">
         <svg-icon [key]="styleItem.iconKey"></svg-icon>
-        <span>{{ styleItem.translationKey | translate }}</span>
+        <span>{{ styleItem.translationKey | smartTranslate }}</span>
       </div>
       }
     </div>

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
@@ -1,17 +1,12 @@
-@if(activeStyle$ | async; as activeStyle) {
+@if (activeStyle$ | async; as activeStyle) {
 <cdk-accordion class="map-legend">
   <cdk-accordion-item #legend="cdkAccordionItem" class="map-legend__content">
     <div [attr.aria-expanded]="legend.expanded" [attr.id]="'legend-header'" class="map-legend__content__header">
-      <button (click)="handleChange()" asset-sg-icon-button class="map-legend__content__header__button">
+      <button (click)="handleChange()" asset-sg-tertiary isIcon>
         <svg-icon [key]="'change'"></svg-icon>
       </button>
       <span class="map-legend__content__header__title">{{ activeStyle.name }}</span>
-      <button
-        (click)="legend.toggle()"
-        [attr.aria-controls]="'legend-body'"
-        asset-sg-icon-button
-        class="map-legend__content__header__button"
-      >
+      <button (click)="legend.toggle()" [attr.aria-controls]="'legend-body'" asset-sg-tertiary isIcon>
         <svg-icon [key]="legend.expanded ? 'arrow-up' : 'arrow-down'"></svg-icon>
       </button>
     </div>
@@ -23,7 +18,7 @@
       [attr.id]="'legend-body'"
       [attr.aria-labelledby]="'legend-header'"
     >
-      @for(styleItem of activeStyle.styleItems; track $index) {
+      @for (styleItem of activeStyle.styleItems; track $index) {
       <div class="map-legend__content__body__item">
         <svg-icon [key]="styleItem.iconKey"></svg-icon>
         <span>{{ styleItem.translationKey | translate }}</span>

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.html
@@ -1,10 +1,11 @@
+@if(activeStyle$ | async; as activeStyle) {
 <cdk-accordion class="map-legend">
   <cdk-accordion-item #legend="cdkAccordionItem" class="map-legend__content">
     <div [attr.aria-expanded]="legend.expanded" [attr.id]="'legend-header'" class="map-legend__content__header">
       <button (click)="handleChange()" asset-sg-icon-button class="map-legend__content__header__button">
         <svg-icon [key]="'change'"></svg-icon>
       </button>
-      <span class="map-legend__content__header__title"> Titel </span>
+      <span class="map-legend__content__header__title">{{ activeStyle.name }}</span>
       <button
         (click)="legend.toggle()"
         [attr.aria-controls]="'legend-body'"
@@ -22,8 +23,14 @@
       [attr.id]="'legend-body'"
       [attr.aria-labelledby]="'legend-header'"
     >
-      Content
+      @for(styleItem of activeStyle.styleItems; track $index) {
+      <div class="map-legend__content__body__item">
+        <svg-icon [key]="styleItem.iconKey"></svg-icon>
+        <span>{{ styleItem.translationKey | translate }}</span>
+      </div>
+      }
     </div>
     }
   </cdk-accordion-item>
 </cdk-accordion>
+}

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
@@ -33,6 +33,14 @@
     &__body {
       background-color: variables.$white;
       padding: 16px;
+      gap: 12px;
+
+      &__item {
+        display: flex;
+        justify-items: flex-start;
+        gap: 8px;
+        align-items: center;
+      }
     }
   }
 }

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
@@ -35,6 +35,7 @@
         justify-items: flex-start;
         gap: 8px;
         align-items: center;
+        font-weight: variables.$font-normal;
       }
     }
   }

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
@@ -23,11 +23,6 @@
       &__title {
         font-weight: variables.$font-bold;
       }
-
-      &__button {
-        height: 100% !important;
-        width: auto !important;
-      }
     }
 
     &__body {

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.scss
@@ -1,0 +1,38 @@
+@use "../../styles/variables";
+
+.map-legend {
+  display: block;
+  width: 184px;
+
+  &__content {
+    display: block;
+    border-radius: 8px;
+    box-shadow: 4px 4px 2px #00000029;
+    overflow: hidden;
+    font-size: 14px;
+
+    &__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      height: 54px;
+      padding: 16px;
+      background-color: variables.$grey-01;
+
+      &__title {
+        font-weight: variables.$font-bold;
+      }
+
+      &__button {
+        height: 100% !important;
+        width: auto !important;
+      }
+    }
+
+    &__body {
+      background-color: variables.$white;
+      padding: 16px;
+    }
+  }
+}

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
@@ -1,10 +1,10 @@
 import { CdkAccordion, CdkAccordionItem } from '@angular/cdk/accordion';
+import { AsyncPipe } from '@angular/common';
 import { Component } from '@angular/core';
 import { ButtonComponent } from '@asset-sg/client-shared';
 import { SvgIconComponent } from '@ngneat/svg-icon';
-import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
-import { AsyncPipe } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
+import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 
 interface MapStyle {
   name: string;
@@ -24,15 +24,15 @@ const mapStyles: MapStyle[] = [
     styleItems: [
       {
         translationKey: 'Asset Punkt',
-        iconKey: 'arrow-up',
+        iconKey: 'geometry-point',
       },
       {
         translationKey: 'Asset Linie',
-        iconKey: 'arrow-down',
+        iconKey: 'geometry-line',
       },
       {
         translationKey: 'Asset Fläche',
-        iconKey: 'settings',
+        iconKey: 'geometry-polygon',
       },
     ],
   },
@@ -42,15 +42,15 @@ const mapStyles: MapStyle[] = [
     styleItems: [
       {
         translationKey: 'Öffentlich',
-        iconKey: 'settings',
+        iconKey: 'access-public',
       },
       {
         translationKey: 'Intern',
-        iconKey: 'arrow-up',
+        iconKey: 'access-internal',
       },
       {
         translationKey: 'gesperrt',
-        iconKey: 'arrow-down',
+        iconKey: 'access-locked',
       },
     ],
   },

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
@@ -1,0 +1,16 @@
+import { CdkAccordion, CdkAccordionItem } from '@angular/cdk/accordion';
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@asset-sg/client-shared';
+import { SvgIconComponent } from '@ngneat/svg-icon';
+
+@Component({
+  selector: 'asset-sg-map-legend',
+  imports: [CdkAccordion, CdkAccordionItem, SvgIconComponent, ButtonComponent],
+  templateUrl: './map-legend.component.html',
+  styleUrl: './map-legend.component.scss',
+})
+export class MapLegendComponent {
+  protected handleChange() {
+    // todo assets-300, assets-420: handle change
+  }
+}

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
@@ -1,11 +1,12 @@
 import { CdkAccordion, CdkAccordionItem } from '@angular/cdk/accordion';
 import { AsyncPipe } from '@angular/common';
 import { Component } from '@angular/core';
-import { ButtonComponent } from '@asset-sg/client-shared';
+import { ButtonComponent, SmartTranslatePipe } from '@asset-sg/client-shared';
 import { SvgIconComponent } from '@ngneat/svg-icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 
+// todo assets-300, assets-420: finalize interface to be used with styling; add translation keys in proper places
 interface MapStyle {
   name: string;
   type: 'geometry' | 'access';
@@ -58,7 +59,15 @@ const mapStyles: MapStyle[] = [
 
 @Component({
   selector: 'asset-sg-map-legend',
-  imports: [CdkAccordion, CdkAccordionItem, SvgIconComponent, ButtonComponent, AsyncPipe, TranslateModule],
+  imports: [
+    CdkAccordion,
+    CdkAccordionItem,
+    SvgIconComponent,
+    ButtonComponent,
+    AsyncPipe,
+    TranslateModule,
+    SmartTranslatePipe,
+  ],
   templateUrl: './map-legend.component.html',
   styleUrl: './map-legend.component.scss',
 })

--- a/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
+++ b/libs/asset-viewer/src/lib/components/map-legend/map-legend.component.ts
@@ -2,15 +2,74 @@ import { CdkAccordion, CdkAccordionItem } from '@angular/cdk/accordion';
 import { Component } from '@angular/core';
 import { ButtonComponent } from '@asset-sg/client-shared';
 import { SvgIconComponent } from '@ngneat/svg-icon';
+import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
+import { AsyncPipe } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+interface MapStyle {
+  name: string;
+  type: 'geometry' | 'access';
+  styleItems: MapStyleItem[];
+}
+
+interface MapStyleItem {
+  translationKey: string;
+  iconKey: string;
+}
+
+const mapStyles: MapStyle[] = [
+  {
+    name: 'Geometrie',
+    type: 'geometry',
+    styleItems: [
+      {
+        translationKey: 'Asset Punkt',
+        iconKey: 'arrow-up',
+      },
+      {
+        translationKey: 'Asset Linie',
+        iconKey: 'arrow-down',
+      },
+      {
+        translationKey: 'Asset Fläche',
+        iconKey: 'settings',
+      },
+    ],
+  },
+  {
+    name: 'Freigabe',
+    type: 'access',
+    styleItems: [
+      {
+        translationKey: 'Öffentlich',
+        iconKey: 'settings',
+      },
+      {
+        translationKey: 'Intern',
+        iconKey: 'arrow-up',
+      },
+      {
+        translationKey: 'gesperrt',
+        iconKey: 'arrow-down',
+      },
+    ],
+  },
+];
 
 @Component({
   selector: 'asset-sg-map-legend',
-  imports: [CdkAccordion, CdkAccordionItem, SvgIconComponent, ButtonComponent],
+  imports: [CdkAccordion, CdkAccordionItem, SvgIconComponent, ButtonComponent, AsyncPipe, TranslateModule],
   templateUrl: './map-legend.component.html',
   styleUrl: './map-legend.component.scss',
 })
 export class MapLegendComponent {
+  private activeStyleIndex = 0;
+  private activeStyleSubject = new BehaviorSubject(mapStyles[this.activeStyleIndex]);
+  protected activeStyle$ = this.activeStyleSubject.asObservable();
+
   protected handleChange() {
     // todo assets-300, assets-420: handle change
+    this.activeStyleIndex = (this.activeStyleIndex + 1) % mapStyles.length;
+    this.activeStyleSubject.next(mapStyles[this.activeStyleIndex]);
   }
 }

--- a/libs/asset-viewer/src/lib/components/map/map.component.html
+++ b/libs/asset-viewer/src/lib/components/map/map.component.html
@@ -2,3 +2,5 @@
 <div #mapControls>
   <asset-sg-map-controls *ngIf="controls != null" [zoom]="controls.zoom" />
 </div>
+
+<asset-sg-map-legend></asset-sg-map-legend>

--- a/libs/asset-viewer/src/lib/components/map/map.component.scss
+++ b/libs/asset-viewer/src/lib/components/map/map.component.scss
@@ -1,5 +1,7 @@
 @use "../../styles/variables";
 
+$map-element-padding: 16px;
+
 :host {
   position: relative;
 }
@@ -16,11 +18,20 @@
 
 asset-sg-map-controls {
   position: absolute;
-  top: 16px;
-  right: 16px;
+  top: $map-element-padding;
+  right: $map-element-padding;
   padding: 0;
 }
 
-:host.is-loading asset-sg-map-controls {
-  opacity: 0;
+asset-sg-map-legend {
+  position: absolute;
+  top: $map-element-padding;
+  left: $map-element-padding;
+}
+
+:host.is-loading {
+  asset-sg-map-controls,
+  asset-sg-map-legend {
+    opacity: 0;
+  }
 }

--- a/libs/client-shared/src/lib/icons/change.ts
+++ b/libs/client-shared/src/lib/icons/change.ts
@@ -1,0 +1,9 @@
+import { icon24x24 } from './icon';
+
+export const changeIcon = {
+  data: icon24x24(
+    '<path d="M16 3L20 7M20 7L16 11M20 7H4M8 21L4 17M4 17L8 13M4 17H20" stroke="currentColor" stroke-width="1.7"' +
+      ' stroke-linecap="round" stroke-linejoin="round"/>'
+  ),
+  name: 'change' as const,
+};

--- a/libs/client-shared/src/lib/icons/index.ts
+++ b/libs/client-shared/src/lib/icons/index.ts
@@ -5,6 +5,7 @@ import { arrowLeftIcon } from './arrow-left';
 import { arrowUpIcon } from './arrow-up';
 import { assetsIcon } from './assets';
 import { calendarIcon } from './calendar';
+import { changeIcon } from './change';
 import { checkIcon } from './check';
 import { checkmarkIcon } from './checkmark';
 import { chevronDownIcon } from './chevron-down';
@@ -21,6 +22,8 @@ import { favoriteIcon } from './favorite';
 import { helpIcon } from './help';
 import { infoIcon } from './info';
 import { infoFilledIcon } from './info-filled';
+import { accessInternalIcon, accessLockedIcon, accessPublicIcon } from './map-styles/access';
+import { geometryLineIcon, geometryPointIcon, geometryPolygonIcon } from './map-styles/geometry';
 import { optionsIcon } from './options';
 import { polygonIcon } from './polygon';
 import { profileIcon } from './profile';
@@ -28,7 +31,6 @@ import { searchIcon } from './search';
 import { settingsIcon } from './settings';
 import { successIcon } from './success';
 import { successFilledIcon } from './success-filled';
-import { changeIcon } from './change';
 import { userManagementIcon } from './user-management';
 import { viewExtendedIcon } from './view-extended';
 import { warnIcon } from './warn';
@@ -76,6 +78,12 @@ export const icons = [
   zoomMinusIcon,
   zoomOriginIcon,
   zoomPlusIcon,
+  geometryPointIcon,
+  geometryLineIcon,
+  geometryPolygonIcon,
+  accessPublicIcon,
+  accessInternalIcon,
+  accessLockedIcon,
 ];
 
 export { icon24x24 } from './icon';

--- a/libs/client-shared/src/lib/icons/index.ts
+++ b/libs/client-shared/src/lib/icons/index.ts
@@ -28,6 +28,7 @@ import { searchIcon } from './search';
 import { settingsIcon } from './settings';
 import { successIcon } from './success';
 import { successFilledIcon } from './success-filled';
+import { changeIcon } from './change';
 import { userManagementIcon } from './user-management';
 import { viewExtendedIcon } from './view-extended';
 import { warnIcon } from './warn';
@@ -67,6 +68,7 @@ export const icons = [
   settingsIcon,
   successIcon,
   successFilledIcon,
+  changeIcon,
   userManagementIcon,
   viewExtendedIcon,
   warningFilledIcon,

--- a/libs/client-shared/src/lib/icons/map-styles/access.ts
+++ b/libs/client-shared/src/lib/icons/map-styles/access.ts
@@ -1,0 +1,98 @@
+export const accessPublicIcon = {
+  data: `
+    <svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_dd_12086_16851)">
+    <mask id="path-1-inside-1_12086_16851" fill="white">
+    <path d="M9 6C9 5.44772 9.44772 5 10 5H24C24.5523 5 25 5.44772 25 6V20C25 20.5523 24.5523 21 24 21H10C9.44772 21 9 20.5523 9 20V6Z"/>
+    </mask>
+    <path d="M9 6C9 5.44772 9.44772 5 10 5H24C24.5523 5 25 5.44772 25 6V20C25 20.5523 24.5523 21 24 21H10C9.44772 21 9 20.5523 9 20V6Z" fill="#10B981"/>
+    <path d="M9 5H25H9ZM25 21H9H25ZM10 21C8.34315 21 7 19.6569 7 18V8C7 6.34315 8.34315 5 10 5H11C11 5 11 5.44772 11 6V20C11 20.5523 11 21 11 21H10ZM25 5V21V5Z" fill="#064E3B" mask="url(#path-1-inside-1_12086_16851)"/>
+    </g>
+    <defs>
+    <filter id="filter0_dd_12086_16851" x="0" y="0" width="34" height="34" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect1_dropShadow_12086_16851"/>
+    <feOffset dy="2"/>
+    <feGaussianBlur stdDeviation="2"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.0627451 0 0 0 0 0.72549 0 0 0 0 0.505882 0 0 0 0.16 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12086_16851"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect2_dropShadow_12086_16851"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="5"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.0627451 0 0 0 0 0.72549 0 0 0 0 0.505882 0 0 0 0.18 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow_12086_16851" result="effect2_dropShadow_12086_16851"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12086_16851" result="shape"/>
+    </filter>
+    </defs>
+    </svg>
+  `,
+  name: 'access-public' as const,
+};
+
+export const accessInternalIcon = {
+  data: `
+    <svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_dd_12086_16855)">
+    <mask id="path-1-inside-1_12086_16855" fill="white">
+    <path d="M9 6C9 5.44772 9.44772 5 10 5H24C24.5523 5 25 5.44772 25 6V20C25 20.5523 24.5523 21 24 21H10C9.44772 21 9 20.5523 9 20V6Z"/>
+    </mask>
+    <path d="M9 6C9 5.44772 9.44772 5 10 5H24C24.5523 5 25 5.44772 25 6V20C25 20.5523 24.5523 21 24 21H10C9.44772 21 9 20.5523 9 20V6Z" fill="#F59E0B"/>
+    <path d="M9 5H25H9ZM25 21H9H25ZM10 21C8.34315 21 7 19.6569 7 18V8C7 6.34315 8.34315 5 10 5H11C11 5 11 5.44772 11 6V20C11 20.5523 11 21 11 21H10ZM25 5V21V5Z" fill="#78350F" mask="url(#path-1-inside-1_12086_16855)"/>
+    </g>
+    <defs>
+    <filter id="filter0_dd_12086_16855" x="0" y="0" width="34" height="34" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect1_dropShadow_12086_16855"/>
+    <feOffset dy="2"/>
+    <feGaussianBlur stdDeviation="2"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.960784 0 0 0 0 0.619608 0 0 0 0 0.0431373 0 0 0 0.16 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12086_16855"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect2_dropShadow_12086_16855"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="5"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.960784 0 0 0 0 0.619608 0 0 0 0 0.0431373 0 0 0 0.18 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow_12086_16855" result="effect2_dropShadow_12086_16855"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12086_16855" result="shape"/>
+    </filter>
+    </defs>
+    </svg>
+  `,
+  name: 'access-internal' as const,
+};
+
+export const accessLockedIcon = {
+  data: `
+    <svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_dd_12086_16859)">
+    <mask id="path-1-inside-1_12086_16859" fill="white">
+    <path d="M9 6C9 5.44772 9.44772 5 10 5H24C24.5523 5 25 5.44772 25 6V20C25 20.5523 24.5523 21 24 21H10C9.44772 21 9 20.5523 9 20V6Z"/>
+    </mask>
+    <path d="M9 6C9 5.44772 9.44772 5 10 5H24C24.5523 5 25 5.44772 25 6V20C25 20.5523 24.5523 21 24 21H10C9.44772 21 9 20.5523 9 20V6Z" fill="#E53940"/>
+    <path d="M9 5H25H9ZM25 21H9H25ZM10 21C8.34315 21 7 19.6569 7 18V8C7 6.34315 8.34315 5 10 5H11C11 5 11 5.44772 11 6V20C11 20.5523 11 21 11 21H10ZM25 5V21V5Z" fill="#801519" mask="url(#path-1-inside-1_12086_16859)"/>
+    </g>
+    <defs>
+    <filter id="filter0_dd_12086_16859" x="0" y="0" width="34" height="34" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect1_dropShadow_12086_16859"/>
+    <feOffset dy="2"/>
+    <feGaussianBlur stdDeviation="2"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.898039 0 0 0 0 0.223529 0 0 0 0 0.25098 0 0 0 0.16 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12086_16859"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect2_dropShadow_12086_16859"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="5"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.898039 0 0 0 0 0.223529 0 0 0 0 0.25098 0 0 0 0.18 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow_12086_16859" result="effect2_dropShadow_12086_16859"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12086_16859" result="shape"/>
+    </filter>
+    </defs>
+    </svg>
+  `,
+  name: 'access-locked' as const,
+};

--- a/libs/client-shared/src/lib/icons/map-styles/geometry.ts
+++ b/libs/client-shared/src/lib/icons/map-styles/geometry.ts
@@ -1,0 +1,89 @@
+export const geometryPointIcon = {
+  data: `
+    <svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_dd_12086_17923)">
+    <circle cx="17" cy="13" r="8" fill="#14AFB8"/>
+    <circle cx="17" cy="13" r="7" stroke="#13474E" stroke-width="2"/>
+    </g>
+    <defs>
+    <filter id="filter0_dd_12086_17923" x="0" y="0" width="34" height="34" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect1_dropShadow_12086_17923"/>
+    <feOffset dy="2"/>
+    <feGaussianBlur stdDeviation="2"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.0784314 0 0 0 0 0.686275 0 0 0 0 0.721569 0 0 0 0.16 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12086_17923"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect2_dropShadow_12086_17923"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="5"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.0784314 0 0 0 0 0.686275 0 0 0 0 0.721569 0 0 0 0.18 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow_12086_17923" result="effect2_dropShadow_12086_17923"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12086_17923" result="shape"/>
+    </filter>
+    </defs>
+    </svg>
+  `,
+  name: 'geometry-point' as const,
+};
+
+export const geometryLineIcon = {
+  data: `
+    <svg width="40" height="38" viewBox="0 0 40 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M11 15.0322L15.3043 7L22.5585 23L29 7.06432" stroke="#1E3A8A" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+    <g filter="url(#filter0_dd_12086_17926)">
+    <path d="M11 15.0322L15.3043 7L22.5585 23L29 7.06432" stroke="#3B82F6" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <defs>
+    <filter id="filter0_dd_12086_17926" x="0.5" y="0.5" width="39" height="37" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect1_dropShadow_12086_17926"/>
+    <feOffset dy="2"/>
+    <feGaussianBlur stdDeviation="2"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.231373 0 0 0 0 0.509804 0 0 0 0 0.964706 0 0 0 0.21 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12086_17926"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect2_dropShadow_12086_17926"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="5"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.231373 0 0 0 0 0.509804 0 0 0 0 0.964706 0 0 0 0.28 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow_12086_17926" result="effect2_dropShadow_12086_17926"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12086_17926" result="shape"/>
+    </filter>
+    </defs>
+    </svg>
+  `,
+  name: 'geometry-line' as const,
+};
+
+export const geometryPolygonIcon = {
+  data: `
+    <svg width="42" height="39" viewBox="0 0 42 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_dd_12086_17934)">
+    <path d="M13.7875 6.13028L9.73276 14.5268C9.30937 15.4036 9.57886 16.4578 10.371 17.0238L22.2488 25.5106C23.3076 26.2671 24.7954 25.8271 25.2723 24.6164L31.9233 7.73305C32.4403 6.42075 31.473 5 30.0625 5H15.5885C14.821 5 14.1213 5.43918 13.7875 6.13028Z" fill="#F59E0B" fill-opacity="0.2"/>
+    <path d="M10.6333 14.9617L14.688 6.56514C14.8549 6.21959 15.2048 6 15.5885 6H30.0625C30.7678 6 31.2514 6.71037 30.9929 7.36653L24.3419 24.2498C24.1035 24.8552 23.3596 25.0752 22.8302 24.6969L10.9524 16.2102C10.5563 15.9272 10.4216 15.4001 10.6333 14.9617Z" stroke="#78350F" stroke-width="2"/>
+    </g>
+    <defs>
+    <filter id="filter0_dd_12086_17934" x="0.53125" y="0" width="40.5312" height="38.8828" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect1_dropShadow_12086_17934"/>
+    <feOffset dy="2"/>
+    <feGaussianBlur stdDeviation="2"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.960784 0 0 0 0 0.619608 0 0 0 0 0.0431373 0 0 0 0.09 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12086_17934"/>
+    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+    <feMorphology radius="1" operator="erode" in="SourceAlpha" result="effect2_dropShadow_12086_17934"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="5"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.960784 0 0 0 0 0.619608 0 0 0 0 0.0431373 0 0 0 0.15 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow_12086_17934" result="effect2_dropShadow_12086_17934"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12086_17934" result="shape"/>
+    </filter>
+    </defs>
+    </svg>
+  `,
+  name: 'geometry-polygon' as const,
+};


### PR DESCRIPTION
Adds the legend component with example data for the style switch.

* Not sure about the icon handling for the legend types - do you have a special way of exporting them from figma? (They now have a small marign at the bottom, which makes them off-centered vertically)
* The legend toggle is implemented as a "mock up", it will probably change once we implement the actual design switch. I could imagine a central store for the style, where the map styling information (i.e. line-width and stuff) is placed, as well as the legend information.
* I reused `asset-sg-button-icon`; its behaviour is odd, though, in that clicking it does not remove the focus, so it stays red.
* I did not yet add the translations; however, that could easily be done once we have the proper styles.

It's not the most generic solution - it _could_ work with more than just two styles, but the icon part still requires some manual work.

@TIL-EBP Not sure if we want to merge this into develop since it's only a mockup - should we maybe create a release branch for the whole feature?