### PR TITLE
Feature 437: Ermögliche Permalinks

### DIFF
--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "develop"
 
+      # TODO remove before merge
+      - "feature/assets-437-ermoegliche-permalinks"
+
   workflow_dispatch:
     inputs:
       version:

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -92,6 +92,11 @@ export class ViewerControllerService {
     let params: ViewerParams;
     if (isEmptyViewerParams(paramsFromUrl) && !isEmptyViewerParams(paramsFromStore)) {
       params = paramsFromStore;
+
+      // `favoritesOnly` is always taken from the URL.
+      // Without this, navigating to any of the viewer pages may have the wrong value set for that filter,
+      // as it fully depends on the current page's path.
+      params = { ...params, query: { ...params.query, favoritesOnly: paramsFromUrl.query.favoritesOnly } };
       await this.viewerParamsService.writeParamsToUrl(params);
       loads.push(this.loadAsset(params.assetId));
     } else {

--- a/libs/client-shared/src/lib/components/disclaimer-dialog/disclaimer-dialog.component.ts
+++ b/libs/client-shared/src/lib/components/disclaimer-dialog/disclaimer-dialog.component.ts
@@ -13,8 +13,6 @@ import { CURRENT_LANG } from '../../utils';
 import { ButtonComponent } from '../button/button.component';
 import { LanguageSelectorComponent } from '../language-selector/language-selector.component';
 
-const LEGAL_BASE_URL = 'https://www.swissgeol.ch/datenschutz';
-
 @Component({
   standalone: true,
   selector: 'asset-sg-disclaimer-dialog',
@@ -42,7 +40,7 @@ export class DisclaimerDialogComponent implements AfterViewInit {
   private readonly currentLang$ = inject(CURRENT_LANG);
   public readonly legalAnchor$ = this.currentLang$.pipe(
     map((lang) => {
-      const url = lang === 'de' ? LEGAL_BASE_URL : `${LEGAL_BASE_URL}-${lang}/`;
+      const url = `https://www.swissgeol.ch/pages/legal/${lang}.html`;
       return `<a href="${url}" target="_blank" rel="noopener nofollow">${url}</a>`;
     })
   );


### PR DESCRIPTION
Resolves #437.
Depends on #479 (mainly to enable a complete DEV deployment from this branch)

Fixes an issue where the value for the `favoritesOnly` was taken from the store (i.e. the last used value) instead of from the URL. This could cause the `/favorites` page to show non-favorited assets, and in turn, cause `/` to show only favorites.

Note that this PR targets `main` instead of `develop`, in order to create a release candidate without including #299 and its colleagues.