### PR TITLE
Feature 437: Ermögliche Permalinks

### DIFF
--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -101,8 +101,8 @@ export class ViewerControllerService {
       loads.push(this.loadAsset(params.assetId));
     } else {
       params = paramsFromUrl;
-      loads.push(this.updateStoreByParams(paramsFromUrl));
     }
+    loads.push(this.updateStoreByParams(paramsFromUrl));
 
     const studies = await firstValueFrom(this.store.select(selectStudies));
     if (studies.length === 0) {

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
@@ -48,7 +48,7 @@ export const selectScrollOffsetForResults = createSelector(
   (state) => state.ui.scrollOffsetForResults
 );
 
-export const selectSearchQuery = createSelector(assetSearchFeature, (state) => state.query);
+export const selectSearchQuery = createSelector(assetSearchFeature, (state) => state?.query ?? {});
 
 export const selectSearchResults = createSelector(assetSearchFeature, (state) => state.results);
 


### PR DESCRIPTION
Resolves #437.

Fixes an issue where the store contains a wrong value for the `favoritesOnly` parameter, causing the map to show geometries instead of the heatmap.