### PR TITLE
Hotfix: Discarded Viewer State

### DIFF
--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -102,7 +102,7 @@ export class ViewerControllerService {
     } else {
       params = paramsFromUrl;
     }
-    loads.push(this.updateStoreByParams(paramsFromUrl));
+    loads.push(this.updateStoreByParams(params));
 
     const studies = await firstValueFrom(this.store.select(selectStudies));
     if (studies.length === 0) {


### PR DESCRIPTION
Fixes a bug introduced in the previous hotfix that caused the viewer to lose its state when being navigated to via the sidebar.