### PR TITLE
Feature 481: Applikations-Ressourcen für grosse Upload skalieren

### DIFF
--- a/k8s/swissgeol-assets/templates/deployment.api.yaml
+++ b/k8s/swissgeol-assets/templates/deployment.api.yaml
@@ -103,12 +103,12 @@ spec:
               value: ''
             - name: OCR_CALLBACK_URL
               value: ''
-      #        resources:
-      #          limits:
-      #            cpu: '0.6'
-      #            memory: 1Gi
-      #          requests:
-      #            cpu: '0.6'
-      #            memory: 500Mi
+          resources:
+            limits:
+              cpu: '1'
+              memory: 4.5Gi
+            requests:
+              cpu: '0.2'
+              memory: 100Mi
       imagePullSecrets:
         - name: {{ .Release.Namespace }}-registry


### PR DESCRIPTION
Resolves #481.

The resources are already deployed on DEV, where the upload of a 1GB+ file has been successful.

See [this comment](https://github.com/swisstopo/swissgeol-assets-suite/issues/481#issuecomment-2786202007) for more information on the impact of this change.