### PR TITLE
Fix SCSS deprecation warning; allow CJS dependency for @turf/jsts

### DIFF
--- a/apps/client-asset-sg/project.json
+++ b/apps/client-asset-sg/project.json
@@ -19,7 +19,16 @@
         "assets": ["apps/client-asset-sg/src/favicon.ico", "apps/client-asset-sg/src/assets"],
         "styles": ["apps/client-asset-sg/src/styles.scss"],
         "scripts": [],
-        "allowedCommonJsDependencies": ["tsafe", "xml-utils", "pbf", "rbush", "earcut", "@prisma/client", "validator"]
+        "allowedCommonJsDependencies": [
+          "tsafe",
+          "xml-utils",
+          "pbf",
+          "rbush",
+          "earcut",
+          "@prisma/client",
+          "validator",
+          "@turf/jsts"
+        ]
       },
       "configurations": {
         "production": {

--- a/apps/client-asset-sg/src/app/components/menu-bar-item/menu-bar-item.component.scss
+++ b/apps/client-asset-sg/src/app/components/menu-bar-item/menu-bar-item.component.scss
@@ -22,15 +22,6 @@
 }
 
 .box > .icon {
-  @include mat.badge-overrides(
-    (
-      background-color: variables.$red,
-      text-color: variables.$white,
-      text-size: 12px,
-      text-weight: 700,
-      text-font: "Inter",
-    )
-  );
   display: flex;
   justify-content: center;
   align-items: center;
@@ -43,6 +34,16 @@
   .mat-badge-content {
     align-content: center;
   }
+
+  @include mat.badge-overrides(
+    (
+      background-color: variables.$red,
+      text-color: variables.$white,
+      text-size: 12px,
+      text-weight: 700,
+      text-font: "Inter",
+    )
+  );
 }
 
 .box {


### PR DESCRIPTION
Closes #525 

I also briefly tried replacing `@turf/buffer` by using plain `jsts`, but they do have a similar CJS issue with one subpackage; and bundlesize would get a tiny bit larger, so not really a solution.