### PR TITLE
Feature/assets 506 admin tab

### DIFF
--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -245,12 +245,6 @@ export const deAppTranslations = {
       },
       administration: {
         tabName: 'Administration',
-        infoGeol: 'InfoGeol',
-        sgsId: 'SGS-ID',
-        data: 'Daten',
-        contactData: 'Kontaktdaten',
-        auxData: 'Zusatzdaten',
-        municipality: 'Gemeinde',
         workStatus: 'Arbeitsstatus',
         lastProcessed: 'Letztes Update',
         by: 'Von',
@@ -259,6 +253,15 @@ export const deAppTranslations = {
           tab: 'Tab',
           hasValidationErrors: 'enthält Validierungsfehler',
         },
+      },
+      legacyData: {
+        tabName: 'Altdaten',
+        infoGeol: 'InfoGeol',
+        sgsId: 'SGS-ID',
+        data: 'Daten',
+        contactData: 'Kontaktdaten',
+        auxData: 'Zusatzdaten',
+        municipality: 'Gemeinde',
       },
       status: {
         tabName: 'Status',

--- a/apps/client-asset-sg/src/app/i18n/en.ts
+++ b/apps/client-asset-sg/src/app/i18n/en.ts
@@ -246,12 +246,6 @@ export const enAppTranslations: AppTranslations = {
       },
       administration: {
         tabName: 'Administration',
-        infoGeol: 'InfoGeol',
-        sgsId: 'SGS ID',
-        data: 'Data',
-        contactData: 'Contact data',
-        auxData: 'Auxiliary data',
-        municipality: 'Municipality',
         workStatus: 'Work status',
         lastProcessed: 'Last processed',
         by: 'By',
@@ -260,6 +254,15 @@ export const enAppTranslations: AppTranslations = {
           tab: 'Tab',
           hasValidationErrors: 'has validation errors',
         },
+      },
+      legacyData: {
+        tabName: 'Legacy data',
+        infoGeol: 'InfoGeol',
+        sgsId: 'SGS ID',
+        data: 'Data',
+        contactData: 'Contact data',
+        auxData: 'Auxiliary data',
+        municipality: 'Municipality',
       },
       status: {
         tabName: 'Status',

--- a/apps/client-asset-sg/src/app/i18n/fr.ts
+++ b/apps/client-asset-sg/src/app/i18n/fr.ts
@@ -247,12 +247,6 @@ export const frAppTranslations: AppTranslations = {
       },
       administration: {
         tabName: 'Administration',
-        infoGeol: 'InfoGeol',
-        sgsId: 'SGS-ID',
-        data: 'Données',
-        contactData: 'Données de contact',
-        auxData: 'Données supplémentaires',
-        municipality: 'Commune',
         workStatus: 'Statut de travail',
         lastProcessed: 'Dernière mise à jour',
         by: 'de',
@@ -261,6 +255,15 @@ export const frAppTranslations: AppTranslations = {
           tab: 'Onglet',
           hasValidationErrors: 'Contient des erreurs de validation',
         },
+      },
+      legacyData: {
+        tabName: 'Administration',
+        infoGeol: 'InfoGeol',
+        sgsId: 'SGS-ID',
+        data: 'Données',
+        contactData: 'Données de contact',
+        auxData: 'Données supplémentaires',
+        municipality: 'Commune',
       },
       status: {
         tabName: 'FR Status',

--- a/apps/client-asset-sg/src/app/i18n/it.ts
+++ b/apps/client-asset-sg/src/app/i18n/it.ts
@@ -246,12 +246,6 @@ export const itAppTranslations: AppTranslations = {
       },
       administration: {
         tabName: 'IT Administration',
-        infoGeol: 'IT InfoGeol',
-        sgsId: 'IT SGS-ID',
-        data: 'IT Daten',
-        contactData: 'IT Kontaktdaten',
-        auxData: 'IT Zusatzdaten',
-        municipality: 'IT Gemeinde',
         workStatus: 'IT Arbeitsstatus',
         lastProcessed: 'IT Letztes Update',
         by: 'IT Von',
@@ -260,6 +254,15 @@ export const itAppTranslations: AppTranslations = {
           tab: 'IT Tab',
           hasValidationErrors: 'IT enthält Validierungsfehler',
         },
+      },
+      legacyData: {
+        tabName: 'IT Administration',
+        infoGeol: 'IT InfoGeol',
+        sgsId: 'IT SGS-ID',
+        data: 'IT Daten',
+        contactData: 'IT Kontaktdaten',
+        auxData: 'IT Zusatzdaten',
+        municipality: 'IT Gemeinde',
       },
       status: {
         tabName: 'IT Status',

--- a/apps/server-asset-sg/src/features/assets/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/assets/search/asset-search.service.ts
@@ -73,7 +73,7 @@ export class AssetSearchService {
       this.elastic,
       this.prisma,
       this.studyRepo,
-      options ?? { index: INDEX, shouldRefresh: true }
+      options ?? { index: INDEX, shouldRefresh: true },
     );
   }
 

--- a/apps/server-asset-sg/src/features/assets/assets/search/asset-search.writer.ts
+++ b/apps/server-asset-sg/src/features/assets/assets/search/asset-search.writer.ts
@@ -22,7 +22,7 @@ export class AssetSearchWriter {
     private readonly elastic: ElasticsearchClient,
     private readonly prisma: PrismaClient,
     private readonly studyRepo: StudyRepo,
-    private readonly options: AssetSearchWriterOptions
+    private readonly options: AssetSearchWriterOptions,
   ) {
     this.eager = options.isEager ? this.fetchEager() : Promise.resolve(null);
   }

--- a/libs/asset-editor/src/lib/asset-editor.module.ts
+++ b/libs/asset-editor/src/lib/asset-editor.module.ts
@@ -31,10 +31,10 @@ import {
   PageHeaderComponent,
   SelectComponent,
   SmartTranslatePipe,
-  TextAreaComponent,
-  TextInputComponent,
   TabComponent,
   TabsComponent,
+  TextAreaComponent,
+  TextInputComponent,
   UsernameComponent,
   ValueItemDescriptionPipe,
   ValueItemNamePipe,
@@ -69,6 +69,7 @@ import { AssetEditorTabReferencesComponent } from './components/asset-editor-tab
 import { AssetEditorTabUsageComponent } from './components/asset-editor-tab-usage/asset-editor-tab-usage.component';
 import { AssetEditorFilesComponent } from './components/asset-editor-tabs/asset-editor-files/asset-editor-files.component';
 import { AssetEditorGeneralComponent } from './components/asset-editor-tabs/asset-editor-general/asset-editor-general.component';
+import { AssetEditorLegacyDataComponent } from './components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component';
 import { AssetEditorStatusApprovalComponent } from './components/asset-editor-tabs/asset-editor-status/asset-editor-status-approval/asset-editor-status-approval.component';
 import { AssetEditorStatusAssigneeComponent } from './components/asset-editor-tabs/asset-editor-status/asset-editor-status-assignee/asset-editor-status-assignee.component';
 import { AssetEditorStatusChangeComponent } from './components/asset-editor-tabs/asset-editor-status/asset-editor-status-change/asset-editor-status-change.component';
@@ -102,6 +103,7 @@ export const canLeaveEdit: CanDeactivateFn<AssetEditorPageComponent> = (componen
     AssetEditorTabReferencesComponent,
     AssetEditorTabUsageComponent,
     AssetEditorGeneralComponent,
+    AssetEditorLegacyDataComponent,
     AssetEditorFilesComponent,
     AssetEditorStatusComponent,
     AssetEditorStatusApprovalComponent,

--- a/libs/asset-editor/src/lib/components/asset-editor-navigation/asset-editor-navigation.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-navigation/asset-editor-navigation.component.ts
@@ -17,12 +17,11 @@ export class AssetEditorNavigationComponent {
   @Input({ required: true })
   public mode!: EditorMode;
 
+  @Input({ required: true })
+  public tabs!: Tab[];
+
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
-
-  public get tabs(): Tab[] {
-    return Object.values(Tab);
-  }
 
   selectTab(tab: Tab): void {
     if (this.activeTab === tab) {
@@ -48,6 +47,6 @@ export enum Tab {
   Contacts = 'contacts',
   References = 'references',
   Geometries = 'geometries',
-  Administration = 'administration',
+  LegacyData = 'legacyData',
   Status = 'status',
 }

--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.html
@@ -20,7 +20,7 @@
   }
 </asset-sg-page-header>
 <div class="editor-container">
-  <asset-sg-editor-navigation [activeTab]="activeTab" [mode]="mode" />
+  <asset-sg-editor-navigation [tabs]="availableTabs" [activeTab]="activeTab" [mode]="mode" />
   <div>
     <div class="form-container">
       @switch (activeTab) {
@@ -33,6 +33,11 @@
         @case (Tab.Status) {
           @if (mode === EditorMode.Edit) {
             <asset-sg-editor-status [workflow]="workflow" />
+          }
+        }
+        @case (Tab.LegacyData) {
+          @if (asset) {
+            <asset-sg-editor-legacy-data [asset]="asset"></asset-sg-editor-legacy-data>
           }
         }
         @default {

--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
@@ -14,7 +14,7 @@ import { AssetEditDetail, dateFromDateId, hasHistoricalData, Lang } from '@asset
 import { Workflow } from '@asset-sg/shared/v2';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
-import { EMPTY, filter, Observable, of, Subscription, switchMap, take, tap } from 'rxjs';
+import { filter, Observable, Subscription, take, tap } from 'rxjs';
 import { EditorMode } from '../../models';
 import * as actions from '../../state/asset-editor.actions';
 import { selectWorkflow } from '../../state/asset-editor.selector';
@@ -69,29 +69,25 @@ export class AssetEditorPageComponent implements OnInit, OnDestroy {
     this.form = buildForm();
     this.loadAssetFromRouteParams();
 
-    this.subscriptions.add(
-      of(this.mode)
-        .pipe(
-          switchMap((mode) => {
-            if (mode === EditorMode.Edit) {
-              return this.store.select(fromAppShared.selectCurrentAsset).pipe(
-                filter((asset) => !!asset),
-                take(1),
-                tap((asset) => {
-                  this.asset = asset;
-                  this.initializeTabs();
-                  this.initializeForm();
-                }),
-              );
-            } else {
+    if (this.mode === EditorMode.Edit) {
+      this.subscriptions.add(
+        this.store
+          .select(fromAppShared.selectCurrentAsset)
+          .pipe(
+            filter((asset) => !!asset),
+            take(1),
+            tap((asset) => {
+              this.asset = asset;
               this.initializeTabs();
               this.initializeForm();
-              return EMPTY;
-            }
-          }),
-        )
-        .subscribe(),
-    );
+            }),
+          )
+          .subscribe(),
+      );
+    } else {
+      this.initializeTabs();
+      this.initializeForm();
+    }
     this.subscriptions.add(
       this.store.select(selectWorkflow).subscribe((workflow) => {
         this.workflow = workflow;
@@ -159,7 +155,7 @@ export class AssetEditorPageComponent implements OnInit, OnDestroy {
 
   private initializeTabs() {
     this.availableTabs = Object.values(Tab).filter((tab) => {
-      return tab !== Tab.LegacyData || !!(this.asset && hasHistoricalData(this.asset))
+      return tab !== Tab.LegacyData || !!(this.asset && hasHistoricalData(this.asset));
     });
   }
 

--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
@@ -159,10 +159,7 @@ export class AssetEditorPageComponent implements OnInit, OnDestroy {
 
   private initializeTabs() {
     this.availableTabs = Object.values(Tab).filter((tab) => {
-      if (tab === Tab.LegacyData) {
-        return !!(this.asset && hasHistoricalData(this.asset));
-      }
-      return true;
+      return tab !== Tab.LegacyData || !!(this.asset && hasHistoricalData(this.asset))
     });
   }
 

--- a/libs/asset-editor/src/lib/components/asset-editor-tab-administration/asset-editor-tab-administration.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tab-administration/asset-editor-tab-administration.component.html
@@ -2,17 +2,17 @@
   <div class="flex flex-row max-h-full">
     <div class="flex flex-column form-column mb-12 mr-8">
       <div class="flex flex-column bg-white py-4 px-6 max-h-full overflow-y-scroll">
-        <div class="font-bold mb-4" translate>edit.tabs.administration.infoGeol</div>
+        <div class="font-bold mb-4" translate>edit.tabs.legacyData.infoGeol</div>
         <mat-form-field class="readonly">
-          <mat-label translate>edit.tabs.administration.sgsId</mat-label>
+          <mat-label translate>edit.tabs.legacyData.sgsId</mat-label>
           <input matInput [value]="_form.controls['sgsId'].value" [readonly]="true" />
         </mat-form-field>
         <mat-form-field class="readonly" floatLabel="always">
-          <mat-label translate>edit.tabs.administration.data</mat-label>
+          <mat-label translate>edit.tabs.legacyData.data</mat-label>
           <textarea matInput [value]="_form.controls['geolDataInfo'].value" [readonly]="true" rows="6"></textarea>
         </mat-form-field>
         <mat-form-field class="readonly" floatLabel="always">
-          <mat-label translate>edit.tabs.administration.contactData</mat-label>
+          <mat-label translate>edit.tabs.legacyData.contactData</mat-label>
           <textarea
             matInput
             [value]="_form.controls['geolContactDataInfo'].value"
@@ -21,7 +21,7 @@
           ></textarea>
         </mat-form-field>
         <mat-form-field class="readonly" floatLabel="always">
-          <mat-label translate>edit.tabs.administration.auxData</mat-label>
+          <mat-label translate>edit.tabs.legacyData.auxData</mat-label>
           <textarea
             matInput
             [value]="_form.controls['geolAuxDataInfo'].value | replaceBr"
@@ -30,7 +30,7 @@
           ></textarea>
         </mat-form-field>
         <mat-form-field class="readonly" floatLabel="always">
-          <mat-label translate>edit.tabs.administration.municipality</mat-label>
+          <mat-label translate>edit.tabs.legacyData.municipality</mat-label>
           <input matInput [value]="_form.controls['municipality'].value" [readonly]="true" />
         </mat-form-field>
       </div>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input } from '@angular/core';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { AssetForm } from '../../asset-editor-page/asset-editor-page.component';
 
-@UntilDestroy()
 @Component({
   selector: 'asset-sg-editor-files',
   styleUrls: ['./asset-editor-files.component.scss'],

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-general/asset-editor-general.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-general/asset-editor-general.component.ts
@@ -2,12 +2,10 @@ import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { fromAppShared, TranslatedValue } from '@asset-sg/client-shared';
 import { AssetEditDetail, ValueItem } from '@asset-sg/shared';
 import { Role, SimpleWorkgroup } from '@asset-sg/shared/v2';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { combineLatestWith, map, Observable, startWith, Subscription } from 'rxjs';
 import { AssetForm } from '../../asset-editor-page/asset-editor-page.component';
 
-@UntilDestroy()
 @Component({
   selector: 'asset-sg-editor-general',
   styleUrls: ['./asset-editor-general.component.scss'],
@@ -23,7 +21,6 @@ export class AssetEditorGeneralComponent implements OnInit, OnDestroy {
   public selectedManCatLabels: TranslatedValueItem[] = [];
   public selectedNatRelItems: TranslatedValueItem[] = [];
   private readonly store = inject(Store);
-  private readonly subscription: Subscription = new Subscription();
   public readonly natRelItems$: Observable<TranslatedValueItem[]> = this.store
     .select(fromAppShared.selectNatRelItems)
     .pipe(map(mapValueItemsToTranslatedItem));
@@ -42,6 +39,7 @@ export class AssetEditorGeneralComponent implements OnInit, OnDestroy {
   public readonly availableWorkgroups$ = this.store
     .select(fromAppShared.selectWorkgroups)
     .pipe(map((workgroups) => workgroups.filter((it) => it.role != Role.Reader)));
+  private readonly subscription: Subscription = new Subscription();
 
   public ngOnInit() {
     this.subscription.add(this.availableWorkgroups$.subscribe((workgroups) => (this.workgroups = workgroups)));

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component.html
@@ -1,0 +1,34 @@
+<div class="wrapper">
+  <asset-sg-detail-section [title]="'edit.tabs.legacyData.infoGeol' | translate">
+    <div class="content column" content>
+      <asset-sg-text-input
+        disabled
+        [value]="asset?.sgsId?.toString() ?? ''"
+        [label]="'edit.tabs.legacyData.sgsId' | translate"
+      ></asset-sg-text-input>
+      <asset-sg-text-area
+        [rows]="5"
+        disabled
+        [value]="asset?.geolDataInfo?.toString() ?? ''"
+        [title]="'edit.tabs.legacyData.data' | translate"
+      ></asset-sg-text-area>
+      <asset-sg-text-area
+        [rows]="5"
+        disabled
+        [value]="asset?.geolContactDataInfo?.toString() ?? ''"
+        [title]="'edit.tabs.legacyData.contactData' | translate"
+      ></asset-sg-text-area>
+      <asset-sg-text-area
+        [rows]="5"
+        disabled
+        [value]="asset?.geolAuxDataInfo?.toString() ?? ''"
+        [title]="'edit.tabs.legacyData.auxData' | translate"
+      ></asset-sg-text-area>
+      <asset-sg-text-input
+        disabled
+        [value]="asset?.municipality?.toString() ?? ''"
+        [label]="'edit.tabs.legacyData.municipality' | translate"
+      ></asset-sg-text-input>
+    </div>
+  </asset-sg-detail-section>
+</div>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component.scss
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component.scss
@@ -1,0 +1,20 @@
+.wrapper {
+  padding: 40px 0;
+  display: flex;
+  flex-direction: column;
+  width: 950px;
+  gap: 24px;
+
+  .content {
+    display: flex;
+    gap: 16px;
+
+    asset-sg-text-area {
+      flex: 1;
+    }
+  }
+
+  .content.column {
+    flex-direction: column;
+  }
+}

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-legacy-data/asset-editor-legacy-data.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { AssetEditDetail } from '@asset-sg/shared';
+
+@Component({
+  selector: 'asset-sg-editor-legacy-data',
+  styleUrls: ['./asset-editor-legacy-data.component.scss'],
+  templateUrl: './asset-editor-legacy-data.component.html',
+  standalone: false,
+})
+export class AssetEditorLegacyDataComponent {
+  @Input() asset: AssetEditDetail | null = null;
+}

--- a/libs/client-shared/src/lib/components/text-area/text-area.component.html
+++ b/libs/client-shared/src/lib/components/text-area/text-area.component.html
@@ -1,3 +1,11 @@
 <label asset-sg-form-item-wrapper [title]="title" [isRequired]="isRequired">
-  <textarea #textarea matInput [ngModel]="value" (ngModelChange)="changeTerm($event)" (blur)="onBlur()"></textarea>
+  <textarea
+    #textarea
+    matInput
+    [rows]="rows"
+    [ngModel]="value"
+    (ngModelChange)="changeTerm($event)"
+    (blur)="onBlur()"
+    [disabled]="disabled"
+  ></textarea>
 </label>

--- a/libs/client-shared/src/lib/components/text-area/text-area.component.scss
+++ b/libs/client-shared/src/lib/components/text-area/text-area.component.scss
@@ -7,8 +7,7 @@
 textarea {
   padding: 8px 12px;
   border: 1px solid variables.$grey-07;
-  max-width: calc(948px - 16px - 25px - 24px);
-  width: calc((948px - 16px - 35px - 24px) / 2);
+  width: 100%;
   max-height: 150px;
   border-radius: 3px;
   font-family: Inter, sans-serif;
@@ -17,5 +16,9 @@ textarea {
 
   &::placeholder {
     color: variables.$grey-10;
+  }
+
+  &:disabled {
+    background-color: #ffffff;
   }
 }

--- a/libs/client-shared/src/lib/components/text-area/text-area.component.ts
+++ b/libs/client-shared/src/lib/components/text-area/text-area.component.ts
@@ -21,10 +21,12 @@ import { FormItemWrapperComponent } from '../form-item-wrapper/form-item-wrapper
   ],
 })
 export class TextAreaComponent implements ControlValueAccessor, AfterViewInit {
+  @Input() public rows?: number = undefined;
   @Input() public title = '';
   @Input() public value = '';
   @Input({ transform: coerceBooleanProperty }) public isRequired = false;
   @Input() public placeholder = '';
+  @Input({ transform: coerceBooleanProperty }) public disabled = false;
   @Output() valueChange = new EventEmitter<string>();
   @ViewChild('textarea') textarea!: ElementRef<HTMLTextAreaElement>;
 

--- a/libs/shared/src/lib/models/asset-edit.ts
+++ b/libs/shared/src/lib/models/asset-edit.ts
@@ -112,6 +112,6 @@ export const AssetEditDetail = C.struct({
 export type AssetEditDetail = C.TypeOf<typeof AssetEditDetail>;
 
 // todo: once AssetEditDetail is removed, a similar property could exist on the new model to avoid this helper method
-export const hasHistoricalData = (asset: AssetEditDetail) => {
-  return asset.geolAuxDataInfo || asset.geolContactDataInfo || asset.geolDataInfo || asset.municipality || asset.sgsId;
+export const hasHistoricalData = (asset: AssetEditDetail): boolean => {
+  return !!(asset.geolAuxDataInfo || asset.geolContactDataInfo || asset.geolDataInfo || asset.municipality || asset.sgsId);
 };

--- a/libs/shared/src/lib/models/asset-edit.ts
+++ b/libs/shared/src/lib/models/asset-edit.ts
@@ -110,3 +110,8 @@ export const AssetEditDetail = C.struct({
   studies: C.array(C.struct({ assetId: C.number, studyId: C.string, geomText: C.string })),
 });
 export type AssetEditDetail = C.TypeOf<typeof AssetEditDetail>;
+
+// todo: once AssetEditDetail is removed, a similar property could exist on the new model to avoid this helper method
+export const hasHistoricalData = (asset: AssetEditDetail) => {
+  return asset.geolAuxDataInfo || asset.geolContactDataInfo || asset.geolDataInfo || asset.municipality || asset.sgsId;
+};

--- a/libs/shared/src/lib/models/asset-edit.ts
+++ b/libs/shared/src/lib/models/asset-edit.ts
@@ -113,5 +113,11 @@ export type AssetEditDetail = C.TypeOf<typeof AssetEditDetail>;
 
 // todo: once AssetEditDetail is removed, a similar property could exist on the new model to avoid this helper method
 export const hasHistoricalData = (asset: AssetEditDetail): boolean => {
-  return !!(asset.geolAuxDataInfo || asset.geolContactDataInfo || asset.geolDataInfo || asset.municipality || asset.sgsId);
+  return !!(
+    asset.geolAuxDataInfo ||
+    asset.geolContactDataInfo ||
+    asset.geolDataInfo ||
+    asset.municipality ||
+    asset.sgsId
+  );
 };


### PR DESCRIPTION
Closes #506 

* Since the data is _never_ editable, I removed the form component for this and just use the hardcoded model
* I did some refactoring where the tabs are generated; mostly because before, that parts was fired twice (once on init, once when the asset was loaded) which seemed off.
* The logic for deciding whether we show the "Altdaten" tab is hardcoded and not generic; we can do it in a generic way should that requirement arise.
* I removeed `@UntilDestroyed` from your components @TIL-EBP as discussed
* I _think_ we could refactor some SCSS, notably the wraper around the page; because this is now duplicated across all pages. However, we could maybe do this at a later stage.
* Note: I asked Simon regarding the SGS-ID, because as I understood it, each asset will ALWAYS have an SGS-ID, so the tab will basically be visible all the time. Should this change, we can remove it.