### PR TITLE
Fix `publish-dev` workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -38,7 +38,7 @@ jobs:
             } = await import('${{ github.workspace }}/.github/scripts/version.utils.mjs');
 
             const [source, target] = await findSourceAndTargetBranches(context);
-            const nextVersion = await determineNextDevVersion(prevVersion, source);
+            const nextVersion = await determineNextDevVersion(source);
 
             return stringifyVersion(nextVersion);
 


### PR DESCRIPTION
Fixes an issue where the next dev version cannot be determined due to the code responsible for that referencing a non-existent variable.