### PR TITLE
Implement alias name for files

### DIFF
--- a/apps/server-asset-sg/src/features/asset-edit/asset-edit.repo.ts
+++ b/apps/server-asset-sg/src/features/asset-edit/asset-edit.repo.ts
@@ -352,8 +352,12 @@ const selectPrismaAsset = selectOnAsset({
   siblingYAssets: { select: { assetX: { select: { assetId: true, titlePublic: true } } } },
   statusWorks: { select: { statusWorkItemCode: true, statusWorkDate: true } },
   assetFiles: {
-    select: { file: { select: { id: true, name: true, size: true, type: true, legalDocItemCode: true } } },
-    orderBy: [{ file: { type: 'asc' } }, { file: { name: 'asc' } }],
+    select: {
+      file: {
+        select: { id: true, fileName: true, fileNameAlias: true, size: true, type: true, legalDocItemCode: true },
+      },
+    },
+    orderBy: [{ file: { type: 'asc' } }, { file: { fileNameAlias: 'asc' } }, { file: { fileName: 'asc' } }],
   },
   workgroupId: true,
 });

--- a/apps/server-asset-sg/src/features/assets/prisma-asset.ts
+++ b/apps/server-asset-sg/src/features/assets/prisma-asset.ts
@@ -1,14 +1,14 @@
 import {
   Asset,
   AssetInfo,
+  AssetStudy,
+  AssetStudyId,
   AssetUsage,
   ContactAssignmentRole,
   LinkedAsset,
-  AssetStudy,
-  AssetStudyId,
-  UsageStatusCode,
   LocalDate,
   StudyType,
+  UsageStatusCode,
 } from '@asset-sg/shared/v2';
 import { Prisma } from '@prisma/client';
 import { satisfy } from '@/utils/define';
@@ -88,7 +88,7 @@ export const assetInfoSelection = satisfy<Prisma.AssetSelect>()({
       file: {
         select: {
           id: true,
-          name: true,
+          fileName: true,
           size: true,
         },
       },
@@ -159,7 +159,7 @@ export const parseAssetInfoFromPrisma = (data: SelectedAssetInfo): AssetInfo => 
   files: data.assetFiles.map((it) => ({
     id: it.file.id,
     size: Number(it.file.size),
-    name: it.file.name,
+    name: it.file.fileName,
   })),
   createdAt: LocalDate.fromDate(data.createDate),
   receivedAt: LocalDate.fromDate(data.receiptDate),

--- a/apps/server-asset-sg/src/features/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/files/file.service.ts
@@ -60,7 +60,7 @@ export class FileService {
     if (!isDbOk) {
       return false;
     }
-    return await this.fileS3Service.delete(file.name);
+    return await this.fileS3Service.delete(file.fileName);
   }
 
   private async saveFileOrDeleteRecord(
@@ -70,7 +70,7 @@ export class FileService {
     options: SaveFileS3Options
   ): Promise<void> {
     try {
-      await this.fileS3Service.save(record.name, content, options);
+      await this.fileS3Service.save(record.fileName, content, options);
     } catch (e) {
       await this.deleteRecordSilently({ id: record.id, assetId }, { reason: `S3 upload failed (${e})` });
       throw e;

--- a/apps/server-asset-sg/src/features/files/files.controller.ts
+++ b/apps/server-asset-sg/src/features/files/files.controller.ts
@@ -22,9 +22,7 @@ import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
 import { authorize } from '@/core/authorize';
 import { CurrentUser } from '@/core/decorators/current-user.decorator';
-import { PrismaService } from '@/core/prisma.service';
 import { AssetEditRepo } from '@/features/asset-edit/asset-edit.repo';
-import { FileOcrService } from '@/features/files/file-ocr.service';
 import { FileS3Service } from '@/features/files/file-s3.service';
 import { FileRepo } from '@/features/files/file.repo';
 import { FileService } from '@/features/files/file.service';
@@ -33,10 +31,8 @@ import { FileService } from '@/features/files/file.service';
 export class FilesController {
   constructor(
     private readonly fileRepo: FileRepo,
-    private readonly fileOcrService: FileOcrService,
     private readonly fileS3Service: FileS3Service,
     private readonly assetEditRepo: AssetEditRepo,
-    private readonly prismaService: PrismaService,
     private readonly fileService: FileService
   ) {}
 
@@ -58,7 +54,7 @@ export class FilesController {
       throw new HttpException('not found', HttpStatus.NOT_FOUND);
     }
 
-    const file = await this.fileS3Service.load(record.name);
+    const file = await this.fileS3Service.load(record.fileName);
     if (file == null) {
       throw new HttpException('not found', HttpStatus.NOT_FOUND);
     }
@@ -69,7 +65,7 @@ export class FilesController {
     if (file.metadata.byteCount != null) {
       res.setHeader('Content-Length', file.metadata.byteCount.toString());
     }
-    res.setHeader('Content-Disposition', `filename="${file.metadata.name}"`);
+    res.setHeader('Content-Disposition', `filename="${record.fileName}"`);
     file.content.pipe(res);
   }
 

--- a/apps/server-asset-sg/src/models/AssetDetailFromPostgres.ts
+++ b/apps/server-asset-sg/src/models/AssetDetailFromPostgres.ts
@@ -15,7 +15,8 @@ import { PostgresAllStudies } from '@/utils/postgres-studies/postgres-studies';
 
 export const AssetFileFromPostgres = D.struct({
   id: D.number,
-  name: D.string,
+  fileName: D.string,
+  fileNameAlias: D.nullable(D.string),
   size: DT.numberFromBigint,
   type: AssetFileType,
   legalDocItemCode: D.nullable(LegalDocItemCode),

--- a/libs/asset-editor/src/lib/asset-editor.module.ts
+++ b/libs/asset-editor/src/lib/asset-editor.module.ts
@@ -22,6 +22,7 @@ import {
   DateTimePipe,
   DrawerComponent,
   DrawerPanelComponent,
+  FileNamePipe,
   fromAppShared,
   MatDateIdModule,
   ValueItemDescriptionPipe,
@@ -155,6 +156,7 @@ export const canLeaveEdit: CanDeactivateFn<AssetEditorPageComponent> = (c) => c.
     ValueItemDescriptionPipe,
     DatePipe,
     DateTimePipe,
+    FileNamePipe,
 
     ViewChildMarker,
     ButtonComponent,

--- a/libs/asset-editor/src/lib/components/asset-editor-files/asset-editor-files.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-files/asset-editor-files.component.html
@@ -6,7 +6,7 @@
         *ngFor="let file of existingFiles; let index = index; let last = last"
         class="list-none bg-grey-00 py-2 pl-4 files mb-2"
       >
-        <div class="name ellipsis">{{ file.name }}</div>
+        <div class="name ellipsis">{{ file | fileName }}</div>
 
         <ng-container *ngIf="file.willBeDeleted; else fileFormFields">
           <div *ngIf="file.willBeDeleted" class="notice text-sm text-grey-08" translate>
@@ -68,7 +68,7 @@
     [class]="{
       'hover:bg-cyan-06': !isDisabled,
       'bg-grey-03': isDisabled,
-      'hover:bg-grey-03': isDisabled | push
+      'hover:bg-grey-03': isDisabled | push,
     }"
     translate
     >edit.tabs.files.selectFile</span

--- a/libs/asset-viewer/src/lib/asset-viewer.module.ts
+++ b/libs/asset-viewer/src/lib/asset-viewer.module.ts
@@ -37,6 +37,7 @@ import {
   DragHandleComponent,
   DrawerComponent,
   DrawerPanelComponent,
+  FileNamePipe,
   SmartTranslatePipe,
   ValueItemDescriptionPipe,
   ValueItemNamePipe,
@@ -137,6 +138,7 @@ import { mapControlReducer } from './state/map-control/map-control.reducer';
     MatChipSet,
     ChipComponent,
     MapLegendComponent,
+    FileNamePipe,
   ],
   providers: [
     TranslatePipe,

--- a/libs/asset-viewer/src/lib/components/asset-viewer-files/asset-viewer-files.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-viewer-files/asset-viewer-files.component.html
@@ -2,11 +2,11 @@
   @if (assetFile.legalDocItem != null) {
   <span class="legal-doc-item-code"> {{ assetFile.legalDocItem | valueItemName }}: </span>
   }
-  <span class="name"> {{ assetFile.name }} ({{ assetFile.size | fileSize : locale }}) </span>
+  <span class="name"> {{ assetFile | fileName }} ({{ assetFile.size | fileSize : locale }}) </span>
   <button
     asset-sg-icon-button
     *ngIf="!isActiveFileDownload(assetFile, 'open-in-tab'); else downloadSpinner"
-    [title]="'search.openFileInNewTab' | translate : { fileName: assetFile.name }"
+    [title]="'search.openFileInNewTab' | translate : { fileName: assetFile | fileName }"
     (click)="downloadFile(assetFile, 'open-in-tab')"
   >
     <svg-icon key="ext-link"></svg-icon>
@@ -14,7 +14,7 @@
   <button
     asset-sg-icon-button
     *ngIf="!isActiveFileDownload(assetFile, 'save-file'); else downloadSpinner"
-    [title]="'search.downloadFile' | translate : { fileName: assetFile.name }"
+    [title]="'search.downloadFile' | translate : { fileName: assetFile | fileName }"
     (click)="downloadFile(assetFile, 'save-file')"
   >
     <svg-icon key="download"></svg-icon>

--- a/libs/asset-viewer/src/lib/components/asset-viewer-files/asset-viewer-files.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-viewer-files/asset-viewer-files.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
-import { AppState, fromAppShared } from '@asset-sg/client-shared';
+import { AppState, FileNamePipe, fromAppShared } from '@asset-sg/client-shared';
 import { AssetFile, AssetFileType } from '@asset-sg/shared';
 import { AssetId } from '@asset-sg/shared/v2';
 import { Store } from '@ngrx/store';
@@ -22,6 +22,8 @@ export class AssetViewerFilesComponent implements OnInit, OnDestroy {
 
   @Input({ required: true })
   type!: AssetFileType;
+
+  private readonly fileNamePipe = inject(FileNamePipe);
 
   private readonly store = inject(Store<AppState>);
 
@@ -62,7 +64,7 @@ export class AssetViewerFilesComponent implements OnInit, OnDestroy {
     this.activeFileDownloads.add(key);
     this.httpClient.get(`/api/assets/${this.assetId}/files/${file.id}`, { responseType: 'blob' }).subscribe({
       next: async (blob) => {
-        const isPdf = file.name.endsWith('.pdf');
+        const isPdf = file.fileName.endsWith('.pdf');
         if (isPdf) {
           blob = await blob.arrayBuffer().then((buffer) => new Blob([buffer], { type: 'application/pdf' }));
         }
@@ -72,7 +74,7 @@ export class AssetViewerFilesComponent implements OnInit, OnDestroy {
         anchor.setAttribute('style', 'display: none');
         anchor.href = url;
         if (!isPdf || downloadType === 'save-file') {
-          anchor.download = file.name;
+          anchor.download = this.fileNamePipe.transform(file);
         } else {
           anchor.target = '_blank';
         }

--- a/libs/client-shared/src/lib/components/file-name.pipe.ts
+++ b/libs/client-shared/src/lib/components/file-name.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { AssetFile } from '@asset-sg/shared';
+
+@Pipe({
+  name: 'fileName',
+  standalone: true,
+})
+export class FileNamePipe implements PipeTransform {
+  transform(value: AssetFile): string {
+    return value.fileNameAlias ?? value.fileName;
+  }
+}

--- a/libs/client-shared/src/lib/components/index.ts
+++ b/libs/client-shared/src/lib/components/index.ts
@@ -16,3 +16,4 @@ export * from './filter-selector';
 export * from './chip';
 export * from './search-and-filter';
 export * from './toggle-status';
+export * from './file-name.pipe';

--- a/libs/persistence/prisma/migrations/20250514120630_file_name_alias/migration.sql
+++ b/libs/persistence/prisma/migrations/20250514120630_file_name_alias/migration.sql
@@ -1,0 +1,15 @@
+-- DropIndex
+DROP INDEX "file_name_key";
+
+-- AlterTable
+ALTER TABLE "file" RENAME COLUMN "name" TO "file_name";
+ALTER TABLE "file"
+  ADD COLUMN "file_name_alias" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "file_file_name_key" ON "file" ("file_name");
+
+-- Copy all values that are prefixed with their asset identifier into alias for the original filename.
+UPDATE "file"
+SET file_name_alias = REGEXP_REPLACE(file_name, '^a[0-9]+_', '')
+WHERE file_name ~ '^a[0-9]+_';

--- a/libs/persistence/prisma/schema.prisma
+++ b/libs/persistence/prisma/schema.prisma
@@ -144,7 +144,10 @@ enum FileType {
 
 model File {
   id             Int      @id @default(autoincrement()) @map("id")
-  name           String   @map("name")
+  /// the filename as stored in the bucket, must be unique and may not be equal to the original file name
+  fileName       String   @map("file_name")
+  /// alias for the given file, typically the original file name
+  fileNameAlias  String?  @map("file_name_alias")
   ocrStatus      OcrState @default(created) @map("ocr_status")
   size           BigInt   @map("size")
   lastModifiedAt DateTime @map("last_modified_at")
@@ -156,7 +159,7 @@ model File {
   AssetObjectInfo AssetObjectInfo[]
   AssetFile       AssetFile[]
 
-  @@unique([name])
+  @@unique([fileName])
   @@index([type])
   @@map("file")
 }

--- a/libs/shared/src/lib/models/asset-edit.ts
+++ b/libs/shared/src/lib/models/asset-edit.ts
@@ -62,7 +62,8 @@ export const eqAssetContactEdit = struct({
 
 export const AssetFile = C.struct({
   id: C.number,
-  name: C.string,
+  fileName: C.string,
+  fileNameAlias: C.nullable(C.string),
   size: C.number,
   type: AssetFileType,
   legalDocItemCode: C.nullable(LegalDocItemCode),


### PR DESCRIPTION
Closes #338 

* I decided to name the field with the filename `fileName` and the alias name `fileNameAlias` and I did only copy those fields that have an alias. Files that are uploaded as-is do not have an alias, so no duplicates needed.
* Note that the naming is _not_ optimal, but `S3Key` would be an even worse choice because we don't want storage technologies tied to our DB name.
* I just assumed that we also need the original file name when downloading an asset

I could not test the full OCR pipeline because that fails locally, but it shouldn't be an issue.