### PR TITLE
Fix publish action installing all node packages

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v4
       - name: "Install dependencies"
-        run: npm install @octokit/rest
+        run: npm install --no-save @octokit/rest
       - name: "Find version"
         id: find-version
         uses: actions/github-script@v7

--- a/.github/workflows/publish-int.yml
+++ b/.github/workflows/publish-int.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v4
       - name: "Install dependencies"
-        run: npm install @octokit/rest
+        run: npm install --no-save @octokit/rest
       - name: "Find version"
         id: find-version
         uses: actions/github-script@v7

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: npm install @octokit/rest
+        run: npm install --no-save @octokit/rest
       - name: Find version
         id: find-version
         uses: actions/github-script@v7
@@ -157,7 +157,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup node
         run: |
-          npm install @octokit/rest
+          npm install --no-save @octokit/rest
       - name: Remove outdated versions
         uses: actions/github-script@v7
         env:


### PR DESCRIPTION
Fixes an issue where the publish workflows attempted to install all node packages although only `@octokit/rest` was required (hope this works).