### PR TITLE
Disable saving on geometry tab as workaround

### DIFF
--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -254,6 +254,8 @@ export const deAppTranslations = {
         instructionsPolygonOrLIne: 'Zeichnen Sie mindestens {{ count }} Punkte',
         instructionsMorePolygonOrLIne: 'Zeichnen Sie mindestens {{ count }} weitere Punkte',
         createGeometry: 'Geometrie erstellen',
+        disabledSave:
+          'Speichern im Geometrie-Tab ist momentan nicht möglich. Bitte wechseln Sie auf einen anderen Tab.',
       },
       administration: {
         tabName: 'Administration',

--- a/apps/client-asset-sg/src/app/i18n/en.ts
+++ b/apps/client-asset-sg/src/app/i18n/en.ts
@@ -253,6 +253,7 @@ export const enAppTranslations: AppTranslations = {
         instructionsPolygonOrLIne: 'Draw at least {{ count }} points',
         instructionsMorePolygonOrLIne: 'Draw at least {{ count }} more points',
         createGeometry: 'Create geometry',
+        disabledSave: 'Saving in the geometries tab is currently not possible. Please switch to another tab.',
       },
       administration: {
         tabName: 'Administration',

--- a/apps/client-asset-sg/src/app/i18n/fr.ts
+++ b/apps/client-asset-sg/src/app/i18n/fr.ts
@@ -254,6 +254,8 @@ export const frAppTranslations: AppTranslations = {
         instructionsPolygonOrLIne: 'Dessinez au moins {{ count }} points',
         instructionsMorePolygonOrLIne: 'Dessinez au moins {{ count }} autres points',
         createGeometry: 'Créer la géométrie',
+        disabledSave:
+          'FR Speichern im Geometrie-Tab ist momentan nicht möglich. Bitte wechseln Sie auf einen anderen Tab.',
       },
       administration: {
         tabName: 'Administration',

--- a/apps/client-asset-sg/src/app/i18n/it.ts
+++ b/apps/client-asset-sg/src/app/i18n/it.ts
@@ -253,6 +253,8 @@ export const itAppTranslations: AppTranslations = {
         instructionsPolygonOrLIne: 'IT Zeichnen Sie mindestens {{ count }} Punkte',
         instructionsMorePolygonOrLIne: 'IT Zeichnen Sie mindestens {{ count }} weitere Punkte',
         createGeometry: 'IT Geometrie erstellen',
+        disabledSave:
+          'IT Speichern im Geometrie-Tab ist momentan nicht möglich. Bitte wechseln Sie auf einen anderen Tab.',
       },
       administration: {
         tabName: 'IT Administration',

--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.html
@@ -64,10 +64,11 @@
     </div>
 
     <asset-sg-editor-save
-      [isSaveDisabled]="form.invalid || !form.dirty"
+      [isSaveDisabled]="form.invalid || !form.dirty || activeTab === Tab.Geometries"
       [hasUnsavedChanges]="form.dirty"
       (discard)="initializeForm()"
       (save)="save()"
+      [tooltip]="activeTab === Tab.Geometries ? ('edit.tabs.geometries.disabledSave' | translate) : undefined"
     ></asset-sg-editor-save>
   </div>
 </div>

--- a/libs/asset-editor/src/lib/components/asset-editor-save/asset-editor-save.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-save/asset-editor-save.component.html
@@ -9,7 +9,7 @@
   edit.discardChanges
   <svg-icon key="delete"></svg-icon>
 </button>
-<button asset-sg-primary (click)="saveChanges()" [disabled]="isSaveDisabled" translate>
+<button asset-sg-primary (click)="saveChanges()" [disabled]="isSaveDisabled" translate [matTooltip]="tooltip">
   save
   <svg-icon key="save"></svg-icon>
 </button>

--- a/libs/asset-editor/src/lib/components/asset-editor-save/asset-editor-save.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-save/asset-editor-save.component.ts
@@ -9,6 +9,7 @@ import { UntilDestroy } from '@ngneat/until-destroy';
   standalone: false,
 })
 export class AssetEditorSaveComponent {
+  @Input() public tooltip?: string;
   @Input() public isSaveDisabled = false;
   @Input() public hasUnsavedChanges = false;
   @Output() public save = new EventEmitter<void>();


### PR DESCRIPTION
Fixes #560 

Due to the madness that is the geometry editor, I took @daniel-va 's advice and just disabled the button on this tab, showing a little tooltip option.