### PR TITLE
Parse legal files via OCR

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -20,7 +20,7 @@ export class FileService {
   async create(data: UploadFileData): Promise<AssetFile> {
     const { content, mediaType, ...createData } = data;
 
-    const isOcrCompatible = data.type !== 'Legal' && mediaType == 'application/pdf';
+    const isOcrCompatible = mediaType == 'application/pdf';
 
     // Store file in DB.
     const record = await this.fileRepo.create({


### PR DESCRIPTION
As discussed with @stijnvermeeren-swisstopo and @mPfifi, legal files should be parsed as well. This will also handle pagecounts for these documents, as mentioned in #551 