### PR TITLE
Bugfix 569: Asset Edit contacts & references

### DIFF
--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.html
@@ -51,7 +51,7 @@
           <asset-sg-editor-references
             [form]="form.controls.references"
             [asset]="asset"
-            [hasWorkgroupId]="!!asset?.workgroupId || !!form.controls.general.controls.workgroupId.value"
+            [workgroupId]="form.controls.general.controls.workgroupId.value ?? asset?.workgroupId ?? null"
           ></asset-sg-editor-references>
         }
         @case (Tab.Geometries) {

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-contacts/asset-editor-contacts.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-contacts/asset-editor-contacts.component.html
@@ -5,7 +5,7 @@
       <svg-icon key="add"></svg-icon>
     </button>
     <div content>
-      @if (asset && dataSource.data.length > 0) {
+      @if (dataSource.data.length > 0) {
         <table [dataSource]="dataSource" mat-table class="mat-elevation-z1 table">
           <ng-container matColumnDef="name">
             <th *matHeaderCellDef mat-header-cell translate>edit.tabs.contacts.name</th>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/add-reference-dialog/add-reference-dialog.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/add-reference-dialog/add-reference-dialog.component.ts
@@ -61,11 +61,22 @@ export class AddReferenceDialogComponent implements OnInit {
 
     this.assetsToIgnore$ = this.form.valueChanges.pipe(
       startWith(this.form.value),
-      map((references) => [
-        ...(references.mainAsset ? [references.mainAsset.assetId] : []),
-        ...(references.siblingAssets?.map((reference) => reference.assetId) ?? []),
-        ...(references.subordinateAssets?.map((reference) => reference.assetId) ?? []),
-      ]),
+      map((references) => {
+        const ids = [] as AssetId[];
+        if (this.asset !== null) {
+          ids.push(this.asset.assetId);
+        }
+        if (references.mainAsset != null) {
+          ids.push(references.mainAsset.assetId);
+        }
+        if (references.siblingAssets != null) {
+          ids.push(...references.siblingAssets.map((it) => it.assetId));
+        }
+        if (references.subordinateAssets != null) {
+          ids.push(...references.subordinateAssets.map((it) => it.assetId));
+        }
+        return ids;
+      }),
     );
     this.assetsToChooseFrom$ = this.searchTerm$.pipe(
       debounceTime(300),

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/asset-editor-references.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/asset-editor-references.component.html
@@ -11,7 +11,7 @@
         <table mat-table [dataSource]="dataSource" class="mat-elevation-z1 table">
           <ng-container matColumnDef="name">
             <th mat-header-cell *matHeaderCellDef>
-              <span translate> edit.tabs.contacts.name</span>
+              <span translate>edit.tabs.contacts.name</span>
             </th>
             <td mat-cell *matCellDef="let reference">{{ reference.titlePublic }}</td>
           </ng-container>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/asset-editor-references.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/asset-editor-references.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { AssetEditDetail, LinkedAsset } from '@asset-sg/shared';
+import { WorkgroupId } from '@asset-sg/shared/v2';
 import { startWith, Subscription } from 'rxjs';
 import { NewReferenceDialogData } from '../../../models/new-reference-dialog-data.interface';
 import { AssetForm } from '../../asset-editor-page/asset-editor-page.component';
@@ -15,8 +16,11 @@ import { AddReferenceDialogComponent } from './add-reference-dialog/add-referenc
 })
 export class AssetEditorReferencesComponent implements OnInit, OnDestroy {
   @Input() form!: AssetForm['controls']['references'];
+
   @Input() asset: AssetEditDetail | null = null;
-  @Input() hasWorkgroupId = false;
+
+  @Input() workgroupId!: WorkgroupId | null;
+
   public COLUMNS = ['name', 'assetId', 'type', 'actions'];
   public dataSource: MatTableDataSource<FormLinkedAsset> = new MatTableDataSource();
   private readonly subscriptions: Subscription = new Subscription();
@@ -78,7 +82,7 @@ export class AssetEditorReferencesComponent implements OnInit, OnDestroy {
         data: {
           form: this.form,
           asset: this.asset,
-          hasWorkgroupId: this.hasWorkgroupId,
+          workgroupId: this.workgroupId,
         },
       },
     );

--- a/libs/asset-editor/src/lib/models/new-reference-dialog-data.interface.ts
+++ b/libs/asset-editor/src/lib/models/new-reference-dialog-data.interface.ts
@@ -1,8 +1,9 @@
 import { AssetEditDetail } from '@asset-sg/shared';
+import { WorkgroupId } from '@asset-sg/shared/v2';
 import { AssetForm } from '../components/asset-editor-page/asset-editor-page.component';
 
 export interface NewReferenceDialogData {
   form: AssetForm['controls']['references'];
   asset: AssetEditDetail | null;
-  hasWorkgroupId: boolean;
+  workgroupId: WorkgroupId | null;
 }


### PR DESCRIPTION
Resolves #569.

- Fixes an issue where after adding a contact in the create-asset form, that contact was then not displayed.
- Fixes an issue where the dialog for adding references did not show an autocomplete dropdown, effectively making it impossible to add references.
- Fixes an issue where assets could self-reference themselves as references.