### PR TITLE
Bugfix 571: Übergeordnete Verweise nur einmal und Verweis auf sich selber nicht möglich

### DIFF
--- a/libs/asset-editor/src/lib/asset-editor.module.ts
+++ b/libs/asset-editor/src/lib/asset-editor.module.ts
@@ -47,6 +47,7 @@ import {
   MatDateIdModule,
   PageHeaderComponent,
   SelectComponent,
+  SelectOptionComponent,
   SmartTranslatePipe,
   TabComponent,
   TabsComponent,
@@ -241,6 +242,7 @@ export const canLeaveEdit: CanDeactivateFn<AssetEditorPageComponent> = (componen
     MatDialogContent,
     MatDialogActions,
     SwissgeolCoreModule,
+    SelectOptionComponent,
   ],
   providers: [
     { provide: MAT_DATE_LOCALE, useValue: de },

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/add-reference-dialog/add-reference-dialog.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-references/add-reference-dialog/add-reference-dialog.component.html
@@ -15,14 +15,14 @@
         [errorMessage]="hasWorkgroupId ? '' : ('edit.tabs.references.workgroupWarning' | translate)"
         isRequired
       ></asset-sg-text-input>
-      <asset-sg-select
-        [title]="'edit.tabs.general.kind' | translate"
-        [values]="types"
-        bindLabel="translation"
-        bindKey="key"
-        isRequired
-        formControlName="type"
-      ></asset-sg-select>
+      <asset-sg-select [title]="'edit.tabs.general.kind' | translate" isRequired formControlName="type">
+        <asset-sg-select-option [value]="LinkedAssetType.Sibling">
+          {{ "edit.tabs.references.referenceType.sibling" | translate }}
+        </asset-sg-select-option>
+        <asset-sg-select-option [value]="LinkedAssetType.Main" [isDisabled]="form.value.mainAsset != null">
+          {{ "edit.tabs.references.referenceType.parent" | translate }}
+        </asset-sg-select-option>
+      </asset-sg-select>
     </div>
   </form>
 </div>

--- a/libs/client-shared/src/lib/components/index.ts
+++ b/libs/client-shared/src/lib/components/index.ts
@@ -15,6 +15,7 @@ export * from './tabs/tabs.component';
 export * from './text-input';
 export * from './text-area/text-area.component';
 export * from './select';
+export * from './select-option/select-option.component';
 export * from './filter-selector';
 export * from './chip';
 export * from './search-and-filter';

--- a/libs/client-shared/src/lib/components/select-option/select-option.component.html
+++ b/libs/client-shared/src/lib/components/select-option/select-option.component.html
@@ -1,0 +1,3 @@
+<ng-template #template>
+  <ng-content />
+</ng-template>

--- a/libs/client-shared/src/lib/components/select-option/select-option.component.ts
+++ b/libs/client-shared/src/lib/components/select-option/select-option.component.ts
@@ -1,0 +1,23 @@
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { CommonModule } from '@angular/common';
+import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatSelectModule } from '@angular/material/select';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'asset-sg-select-option',
+  imports: [CommonModule, MatSelectModule, ReactiveFormsModule, TranslateModule, FormsModule],
+  templateUrl: './select-option.component.html',
+  styleUrl: './select-option.component.scss',
+})
+export class SelectOptionComponent<T> {
+  @Input({ required: true })
+  value!: T;
+
+  @Input({ transform: coerceBooleanProperty })
+  isDisabled = false;
+
+  @ViewChild('template')
+  template!: TemplateRef<unknown>;
+}

--- a/libs/client-shared/src/lib/components/select/select.component.html
+++ b/libs/client-shared/src/lib/components/select/select.component.html
@@ -15,11 +15,23 @@
         </mat-select-trigger>
       }
       @for (value of values; track value) {
-        <mat-option [value]="value">{{ (bindLabel ? $any(value[bindLabel]) : value) | smartTranslate }}</mat-option>
+        <mat-option [value]="value">
+          {{ (bindLabel ? $any(value[bindLabel]) : value) | smartTranslate }}
+        </mat-option>
+      }
+
+      @for (option of customOptionsToRender; track option.value) {
+        <mat-option [value]="option.value" [disabled]="option.isDisabled">
+          <ng-container *ngTemplateOutlet="option.template" />
+        </mat-option>
       }
     </mat-select>
     @if (errorMessage) {
       <mat-hint class="mat-mdc-form-field-error">{{ errorMessage }}</mat-hint>
     }
   </mat-form-field>
+
+  <div style="display: none">
+    <ng-content />
+  </div>
 </label>

--- a/libs/client-shared/src/lib/components/select/select.component.ts
+++ b/libs/client-shared/src/lib/components/select/select.component.ts
@@ -92,8 +92,6 @@ export class SelectComponent<T, K> implements OnInit, AfterViewInit, ControlValu
   }
 
   public onFilterChange(selectedValues: T | T[]): void {
-    console.log(selectedValues);
-
     this.selectedValues = selectedValues;
     this.selectionChanged.emit(
       Array.isArray(selectedValues) ? selectedValues.map((it) => this.getKey(it)) : [this.getKey(selectedValues)],


### PR DESCRIPTION
Resolves #571.
Depends on #569.

Fixes an issue where the parent asset could be replaced by assigning a new parent asset. This is done by greying out the `main` option in the type selection for new references.

For this to be possible, I had to extend the `asset-sg-select` with the `asset-sg-select-option` component, which enables more fine-grained control over specific select options.