### PR TITLE
Bugfix 575: Asset Edit contacts & references

### DIFF
--- a/apps/server-asset-sg/src/features/assets/asset-edit/asset-edit.repo.ts
+++ b/apps/server-asset-sg/src/features/assets/asset-edit/asset-edit.repo.ts
@@ -106,6 +106,11 @@ export class AssetEditRepo implements Repo<AssetEditDetail, number, AssetEditDat
         },
       });
 
+      await this.prismaService.assetXAssetY.createMany({
+        data: data.patch.siblingAssetIds.map((assetYId) => ({ assetXId: asset.assetId, assetYId })),
+        skipDuplicates: true,
+      });
+
       await createStudies(this.prismaService, asset.assetId, data.patch.newStudies)();
 
       return (await this.find(asset.assetId)) as AssetEditDetail;


### PR DESCRIPTION
Resolves #575.

Once again, this was a bug that was present before the edit redesign, but only now has been noticed.