### PR TITLE
Bugfix 586: Erstellen neues Asset: jedes Speichern führt zu einer Verdoppelung

### DIFF
--- a/apps/client-asset-sg/src/app/state/app-shared.reducer.ts
+++ b/apps/client-asset-sg/src/app/state/app-shared.reducer.ts
@@ -21,6 +21,13 @@ const initialState: AppSharedState = {
 export const appSharedStateReducer = createReducer(
   initialState,
   on(
+    assetSearchActions.resetSearch,
+    (state): AppSharedState => ({
+      ...state,
+      currentAsset: null,
+    }),
+  ),
+  on(
     appSharedStateActions.setCurrentAsset,
     (state, { asset, isLoading }): AppSharedState => ({
       ...state,
@@ -29,10 +36,10 @@ export const appSharedStateReducer = createReducer(
     }),
   ),
   on(
-    assetSearchActions.resetSearch,
-    (state): AppSharedState => ({
+    appSharedStateActions.updateAsset,
+    (state, { asset, shouldBeCurrentAsset }): AppSharedState => ({
       ...state,
-      currentAsset: null,
+      currentAsset: shouldBeCurrentAsset || state.currentAsset?.assetId === asset.assetId ? asset : state.currentAsset,
     }),
   ),
   on(
@@ -40,14 +47,6 @@ export const appSharedStateReducer = createReducer(
     (state, { assetId }): AppSharedState => ({
       ...state,
       currentAsset: state.currentAsset?.assetId === assetId ? null : state.currentAsset,
-    }),
-  ),
-
-  on(
-    appSharedStateActions.updateAsset,
-    (state, { asset }): AppSharedState => ({
-      ...state,
-      currentAsset: state.currentAsset?.assetId === asset.assetId ? asset : state.currentAsset,
     }),
   ),
   on(
@@ -77,7 +76,7 @@ export const appSharedStateReducer = createReducer(
   on(appSharedStateActions.setLang, (state, { lang }): AppSharedState => ({ ...state, lang })),
   on(
     appSharedStateActions.createContactResult,
-    (state, { type, ...contact }): AppSharedState => ({
+    (state, { type: _, ...contact }): AppSharedState => ({
       ...state,
       rdReferenceData: pipe(
         state.rdReferenceData,
@@ -90,7 +89,7 @@ export const appSharedStateReducer = createReducer(
   ),
   on(
     appSharedStateActions.editContactResult,
-    (state, { type, ...contact }): AppSharedState => ({
+    (state, { type: _, ...contact }): AppSharedState => ({
       ...state,
       rdReferenceData: pipe(
         state.rdReferenceData,

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-general/asset-editor-general.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-general/asset-editor-general.component.html
@@ -6,7 +6,6 @@
         [values]="availableWorkgroups$ | push"
         [bindLabel]="'name'"
         [bindKey]="'id'"
-        [disabled]="hasReferences"
         errorMessage="{{ hasReferences ? ('edit.tabs.general.referencesWarning' | translate) : '' }}"
         isRequired
         formControlName="workgroupId"

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-general/asset-editor-general.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-general/asset-editor-general.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { fromAppShared } from '@asset-sg/client-shared';
 import { AssetEditDetail } from '@asset-sg/shared';
 import { Role, SimpleWorkgroup } from '@asset-sg/shared/v2';
@@ -14,7 +14,7 @@ import { AssetForm } from '../../asset-editor-page/asset-editor-page.component';
   templateUrl: './asset-editor-general.component.html',
   standalone: false,
 })
-export class AssetEditorGeneralComponent implements OnInit, OnDestroy {
+export class AssetEditorGeneralComponent implements OnInit, OnChanges, OnDestroy {
   @Input() form!: AssetForm['controls']['general'];
   @Input() asset: AssetEditDetail | null = null;
   @Input() hasReferences = false;
@@ -67,6 +67,17 @@ export class AssetEditorGeneralComponent implements OnInit, OnDestroy {
           this.selectedLanguages = langs?.map((lang) => lang.languageItemCode) ?? [];
         }),
     );
+  }
+
+  public ngOnChanges(changes: SimpleChanges) {
+    if ('hasReferences' in changes) {
+      const { workgroupId: workgroupIdControl } = this.form.controls;
+      if (this.hasReferences) {
+        workgroupIdControl.disable();
+      } else {
+        workgroupIdControl.enable();
+      }
+    }
   }
 
   public ngOnDestroy() {

--- a/libs/asset-editor/src/lib/state/asset-editor.effects.ts
+++ b/libs/asset-editor/src/lib/state/asset-editor.effects.ts
@@ -105,6 +105,7 @@ export class AssetEditorEffects {
       ofType(actions.updateAssetEditDetailResult),
       map(({ asset }) =>
         appSharedStateActions.updateAsset({
+          shouldBeCurrentAsset: true,
           asset: {
             ...asset,
             studies: asset.studies.map((it) => ({

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.reducer.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.reducer.ts
@@ -152,7 +152,6 @@ export const assetSearchReducer = createReducer(
       studies: state.studies?.filter((study) => study.assetId !== assetId) ?? null,
     }),
   ),
-
   on(appSharedStateActions.updateAsset, (state, { asset }): AssetSearchState => {
     return {
       ...state,

--- a/libs/client-shared/src/lib/state/app-shared-state.actions.ts
+++ b/libs/client-shared/src/lib/state/app-shared-state.actions.ts
@@ -50,6 +50,7 @@ export const updateAsset = createAction(
   '[App Shared State] Update Asset In Search',
   props<{
     asset: AssetEditDetail;
+    shouldBeCurrentAsset?: boolean;
   }>(),
 );
 


### PR DESCRIPTION
Resolves #586.

Fixes an issue where after creating a new asset with files, any following form submissions will duplicate these files. This happened due to the form not being correctly reset when switching from new asset to edit asset mode.

This PR fixes this behavior by correctly updating the selected asset in the store after saving the form, and correctly reacting to that store update afterward.