### PR TITLE
Implement sync service from extern to intern

### DIFF
--- a/apps/sync-asset-sg/.env
+++ b/apps/sync-asset-sg/.env
@@ -18,3 +18,6 @@ DESTINATION_WORKGROUP_IDS='1'
 
 # view|extern
 MODE='view'
+
+# Default assigne for extern mode
+SYNC_ASSIGNEE=marcel.pfiffner@swisstopo.ch

--- a/apps/sync-asset-sg/src/core/config.ts
+++ b/apps/sync-asset-sg/src/core/config.ts
@@ -2,6 +2,7 @@ export type Mode = 'view' | 'extern';
 
 export interface SyncConfig {
   mode: Mode;
+  syncAssignee: string | undefined;
   source: {
     connectionString: string;
     allowedWorkgroupIds: number[];
@@ -23,6 +24,7 @@ function getEnvOrThrow(key: string): string {
 export function getConfig(): SyncConfig {
   return {
     mode: getEnvOrThrow('MODE') as Mode,
+    syncAssignee: process.env['SYNC_ASSIGNEE'],
     source: {
       connectionString: getEnvOrThrow('SOURCE_CONNECTION_STRING'),
       allowedWorkgroupIds: process.env['SOURCE_WORKGROUP_IDS']?.split(',').map(Number) ?? [],

--- a/apps/sync-asset-sg/src/core/sync-extern.service.ts
+++ b/apps/sync-asset-sg/src/core/sync-extern.service.ts
@@ -134,11 +134,11 @@ export class SyncExternService {
 
   private async init() {
     this.syncAssignee = (
-      await this.destinationPrisma.assetUser.findFirst({
+      await this.destinationPrisma.assetUser.findFirstOrThrow({
         select: { id: true },
         where: { email: this.config.syncAssignee },
       })
-    )?.id;
+    ).id;
 
     (await this.destinationPrisma.contact.findMany()).forEach((c) =>
       this.existingContactIds.set(this.createUniqueContactKey(c), c.contactId),

--- a/apps/sync-asset-sg/src/core/sync-extern.service.ts
+++ b/apps/sync-asset-sg/src/core/sync-extern.service.ts
@@ -1,14 +1,32 @@
-import { PrismaClient } from '@prisma/client';
+import {
+  Asset,
+  AssetContact,
+  AssetLanguage,
+  AssetSynchronization,
+  Contact,
+  File,
+  Id,
+  ManCatLabelRef,
+  Prisma,
+  PrismaClient,
+  TypeNatRel,
+} from '@prisma/client';
 import { SyncConfig } from './config';
 import { log } from './log';
 
+const BATCH_SIZE = 10_000;
+
 export class SyncExternService {
   private readonly config: SyncConfig;
-
+  private readonly existingContactIds: Map<string, number> = new Map();
+  private readonly relationSqls: RelationSqls = { ids: [], assetLanguages: [], manCatLabelRefs: [], typeNatRels: [] };
+  private readonly existingFileIds: Map<string, number> = new Map();
+  private readonly assetsToSync: AssetToSync[] = [];
+  private readonly newAssetToOriginalAsset: Map<number, { originalAssetId: number; originalSgsId: number }> = new Map();
+  private readonly geometries: Geometries = { areas: new Map(), locations: new Map(), traces: new Map() };
   private readonly sourcePrisma: PrismaClient;
   private readonly destinationPrisma: PrismaClient;
-
-  private readonly batchSize = 500;
+  private syncAssignee: string | null = null;
 
   constructor(sourcePrisma: PrismaClient, destinationPrisma: PrismaClient, config: SyncConfig) {
     this.config = config;
@@ -17,54 +35,403 @@ export class SyncExternService {
   }
 
   /**
-   * Synchronize data between source and destination databases.
-   * All content in source database should be copied to destination database.
-   * Only assets from the allowed workgroups should be copied.
-   * From the destination database, only the assets with workgroup in destination workgroup ids
-   * should be copied.
+   * Synchronizes assets from an external source to the internal, matching potentially existing objects.
+   *
+   * Does not synchronize the following:
+   * - Authors (external sources should not have matching authors, since that's the purpose of external apps)
+   * - Favourites (external users should not have access to internal data)
+   * - Workflows (we create new workflows with a default message for imported data)
+   * - SiblingY are not synchronized (we only synchronize SiblingX, so we do not perform a lookup for potentially missing SiblingY links in future synchronizations)
    */
-  public async syncProdAndExtern() {
-    log('Starting data export to extern');
+  public async syncExternalToInternal() {
+    log('Starting data export from external');
+    await this.init();
 
-    const sourceAssets = await this.sourcePrisma.asset.findMany({
-      where: {
-        workgroup: {
-          id: {
-            in: this.config.source.allowedWorkgroupIds,
-          },
-        },
-      },
-    });
-
-    log(`Found ${sourceAssets.length} assets in source database`);
-
-    const destinationAssets = await this.destinationPrisma.asset.findMany({
-      where: {
-        workgroup: {
-          id: {
-            in: this.config.destination.allowedWorkgroupIds,
-          },
-        },
-      },
-    });
-
-    log(`Found ${destinationAssets.length} assets in destination database`);
-
-    const sourceAssetIds = new Set(sourceAssets.map((asset) => asset.assetId));
-    const destinationAssetIds = new Set(destinationAssets.map((asset) => asset.assetId));
-
-    const assetsToCopy = sourceAssets.filter((asset) => !destinationAssetIds.has(asset.assetId));
-
-    log(`Found ${assetsToCopy.length} assets to copy`, 'batch');
-
-    for (let i = 0; i < assetsToCopy.length; i += this.batchSize) {
-      const batch = assetsToCopy.slice(i, i + this.batchSize);
-      await this.destinationPrisma.asset.createMany({
-        data: batch,
-      });
-      log(`Copied ${batch.length} assets`, 'batch');
+    log(`Starting synchronization of ${this.assetsToSync.length} assets`);
+    for (const asset of this.assetsToSync) {
+      await this.synchronizeAsset(asset);
     }
+    log(`Synced ${this.newAssetToOriginalAsset.size} assets`);
 
+    await this.createWorkflows();
+    const assetSynchronizations = await this.createAssetSynchronizationRecords();
+    await this.createRelationTables();
+    await this.createGeometriesForAssets();
+    await this.createSiblings(assetSynchronizations);
     log('Data export to extern completed');
   }
+
+  private async synchronizeAsset(asset: AssetToSync) {
+    const contactsCreate = await this.createContactsPayload(asset.assetContacts);
+    const filesCreate = await this.createFilesPayload(asset.assetFiles);
+
+    const newAsset = await this.destinationPrisma.asset.create({
+      include: { assetFiles: { include: { file: true } }, assetContacts: { include: { contact: true } } },
+      data: {
+        ...asset.asset,
+        assetMainId: null, // this will be set afterwards
+        isPublic: false,
+        assetFiles: filesCreate,
+        assetContacts: contactsCreate,
+      },
+    });
+
+    // since contacts and files _might_ be created, we just override the entries in the map regardless of whether they existed or not
+    newAsset.assetContacts
+      .map((a) => a.contact)
+      .forEach((c) => this.existingContactIds.set(this.createUniqueContactKey(c), c.contactId));
+    newAsset.assetFiles.map((a) => a.file).forEach((f) => this.existingFileIds.set(f.name, f.id));
+
+    this.newAssetToOriginalAsset.set(newAsset.assetId, {
+      originalAssetId: asset.originalAssetId,
+      originalSgsId: asset.originalSgsId,
+    });
+
+    this.relationSqls.ids.push(...asset.ids.map((i) => Prisma.sql`(${newAsset.assetId}, ${i.id}, ${i.description})`));
+    this.relationSqls.assetLanguages.push(
+      ...asset.assetLanguages.map((a) => Prisma.sql`(${newAsset.assetId}, ${a.languageItemCode})`),
+    );
+    this.relationSqls.manCatLabelRefs.push(
+      ...asset.manCatLabelRefs.map((m) => Prisma.sql`(${newAsset.assetId}, ${m.manCatLabelItemCode})`),
+    );
+    this.relationSqls.typeNatRels.push(
+      ...asset.typeNatRels.map((t) => Prisma.sql`(${newAsset.assetId}, ${t.natRelItemCode})`),
+    );
+  }
+
+  /**
+   * Creates a lookup key for storing contact ids for easy retrieval so we don't have to fetch potentially existing
+   * contacts for each entry we want to create.
+   */
+  private createUniqueContactKey(contact: Omit<Contact, 'contactId'>): string {
+    return `${contact.name}||${contact.locality}||${contact.street}||${contact.country}||${contact.street}||${contact.plz}||${contact.email}||${contact.houseNumber}||${contact.website}||${contact.telephone}`;
+  }
+
+  private async createSiblings(assetSynchronizations: AssetSynchronization[]) {
+    log('Syncing siblings');
+    const existingSiblings = await this.sourcePrisma.assetXAssetY.findMany({
+      where: { assetXId: { in: this.assetsToSync.map((a) => a.originalAssetId) } },
+    });
+    for (const asset of this.assetsToSync) {
+      const newAssetId = assetSynchronizations.find((n) => n.originalAssetId === asset.originalAssetId);
+      const assetMainLink = assetSynchronizations.find((n) => n.originalAssetId === asset.asset.assetMainId);
+      const originalAssetXSiblings = existingSiblings
+        .filter((n) => n.assetXId === asset.originalAssetId)
+        .map((n) => n.assetYId);
+      const newAssetSiblings = assetSynchronizations
+        .filter((n) => originalAssetXSiblings.includes(n.originalAssetId))
+        .map((n) => n.assetId);
+
+      await this.destinationPrisma.asset.update({
+        where: { assetId: newAssetId.assetId },
+        data: {
+          assetMainId: assetMainLink?.assetId,
+          siblingXAssets: { create: newAssetSiblings.map((n) => ({ assetYId: n })) },
+        },
+      });
+    }
+  }
+
+  private async init() {
+    this.syncAssignee = (
+      await this.destinationPrisma.assetUser.findFirst({
+        select: { id: true },
+        where: { email: this.config.syncAssignee },
+      })
+    )?.id;
+
+    (await this.destinationPrisma.contact.findMany()).forEach((c) =>
+      this.existingContactIds.set(this.createUniqueContactKey(c), c.contactId),
+    );
+
+    (await this.destinationPrisma.file.findMany()).forEach((f) => this.existingFileIds.set(f.name, f.id));
+
+    const alreadySyncedIds = (
+      await this.destinationPrisma.assetSynchronization.findMany({
+        select: { originalAssetId: true },
+      })
+    ).map((res) => res.originalAssetId);
+    log(`Found ${alreadySyncedIds.length} already synced IDs which will be skipped`);
+
+    const assetsToSync: AssetToSync[] = (
+      await this.sourcePrisma.asset.findMany({
+        where: {
+          assetId: {
+            notIn: alreadySyncedIds,
+          },
+          isPublic: true,
+        },
+        include: {
+          ids: { select: { id: true, description: true } },
+          assetLanguages: { select: { languageItemCode: true } },
+          manCatLabelRefs: { select: { manCatLabelItemCode: true } },
+          typeNatRels: { select: { natRelItemCode: true } },
+          assetContacts: {
+            include: {
+              contact: true,
+            },
+          },
+          assetFiles: {
+            include: {
+              file: true,
+            },
+          },
+        },
+      })
+    ).map((item) => {
+      const { assetId, sgsId, assetFiles, assetContacts, manCatLabelRefs, typeNatRels, ids, assetLanguages, ...asset } =
+        item;
+      return {
+        asset,
+        manCatLabelRefs,
+        assetLanguages,
+        typeNatRels,
+        ids,
+        assetContacts: assetContacts,
+        assetFiles: assetFiles.flatMap((a) => a.file),
+        originalAssetId: assetId,
+        originalSgsId: sgsId,
+      };
+    });
+    this.assetsToSync.push(...assetsToSync);
+    log(`Found ${this.assetsToSync.length} assets in source database which need to be synced`);
+
+    this.geometries.traces = await this.fetchExistingGeometriesForAssets('trace');
+    this.geometries.areas = await this.fetchExistingGeometriesForAssets('area');
+    this.geometries.locations = await this.fetchExistingGeometriesForAssets('location');
+    log(`Fetched original geometries for assets to sync`);
+  }
+
+  /**
+   * Creates an input for asset contacts by either connecting to existing contacts or by creating a new contact.
+   */
+  private async createContactsPayload(
+    assetContacts: (AssetContact&{contact: Contact})[], // prettier-ignore
+  ): Promise<Prisma.AssetContactUncheckedCreateNestedManyWithoutAssetInput> {
+    return {
+      create: assetContacts.map(({ role, contact: { contactId: _, ...contact } }) => {
+        const match = this.existingContactIds.get(this.createUniqueContactKey(contact));
+        return {
+          role,
+          contact: match ? { connect: { contactId: match } } : { create: contact },
+        };
+      }),
+    };
+  }
+
+  /**
+   * Creates an input for asset files by either connecting to existing files (matched by name) or by creating a new file
+   * entry.
+   */
+  private async createFilesPayload(
+    assetFiles: File[],
+  ): Promise<Prisma.AssetFileUncheckedCreateNestedManyWithoutAssetInput> {
+    const create = assetFiles.map(({ id: _, ...file }) => {
+      const match = this.existingFileIds.get(file.name);
+
+      return match
+        ? { file: { connect: { id: match } } }
+        : (() => {
+            return { file: { create: file } };
+          })();
+    });
+
+    return { create };
+  }
+
+  private async fetchExistingGeometriesForAssets(
+    tableType: 'area' | 'location' | 'trace',
+  ): Promise<StudyGeometriesPerAsset> {
+    const assetIds = this.assetsToSync.map((a) => a.originalAssetId);
+    const query = `SELECT
+        study_${tableType}_id       AS "id",
+        asset_id            AS "assetId",
+        ST_ASBINARY(geom)   AS "geom",
+        is_revised          AS "isRevised"
+    FROM study_${tableType}
+    WHERE asset_id IN (${assetIds.join(',')})
+    `;
+
+    const result = await this.sourcePrisma.$queryRawUnsafe<StudyGeometry[]>(query);
+    const resultSet = new Map<number, StudyGeometryTransfer[]>();
+
+    result.forEach(({ assetId, ...data }) => {
+      if (!resultSet.has(assetId)) {
+        resultSet.set(assetId, [data]);
+      } else {
+        resultSet.get(assetId)?.push(data);
+      }
+    });
+
+    return resultSet;
+  }
+
+  private async createGeometriesForAssets() {
+    log('Begin geometry insert');
+    const buildRows = <T extends { geom: Uint8Array | string; isRevised: boolean }>(list: T[], newAssetId: number) =>
+      list.map(({ geom, isRevised }) => Prisma.sql`(${newAssetId}, ST_GeomFromWKB(${geom}), ${isRevised})`);
+
+    const areasSql: Prisma.Sql[] = [];
+    const locationsSql: Prisma.Sql[] = [];
+    const tracesSql: Prisma.Sql[] = [];
+    this.newAssetToOriginalAsset.forEach(({ originalAssetId }, newAssetId) => {
+      areasSql.push(...buildRows(this.geometries.areas.get(originalAssetId) ?? [], newAssetId));
+      locationsSql.push(...buildRows(this.geometries.locations.get(originalAssetId) ?? [], newAssetId));
+      tracesSql.push(...buildRows(this.geometries.traces.get(originalAssetId) ?? [], newAssetId));
+    });
+
+    for (const [idx, batch] of this.batchList(areasSql, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of areas`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+          INSERT INTO study_area (asset_id, geom, is_revised)
+          VALUES ${Prisma.join(batch)}
+        `;
+      log(`Finished batch #${idx + 1} of areas`, 'batch');
+    }
+
+    for (const [idx, batch] of this.batchList(locationsSql, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of locations`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+          INSERT INTO study_location (asset_id, geom, is_revised)
+          VALUES ${Prisma.join(batch)}
+        `;
+      log(`Finished batch #${idx + 1} of locations`, 'batch');
+    }
+
+    for (const [idx, batch] of this.batchList(tracesSql, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of traces`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+          INSERT INTO study_trace (asset_id, geom, is_revised)
+          VALUES ${Prisma.join(batch)}
+        `;
+      log(`Finished batch #${idx + 1} of traces`, 'batch');
+    }
+  }
+
+  private batchList<T>(list: T[], batchSize: number): T[][] {
+    const batches = [];
+    for (let i = 0; i < list.length; i += batchSize) {
+      batches.push(list.slice(i, i + batchSize));
+    }
+    return batches;
+  }
+
+  private async createRelationTables() {
+    log('Create batched relation entries');
+    for (const [idx, batch] of this.batchList(this.relationSqls.ids, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of ids`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+              INSERT INTO id (asset_id, id, description)
+              VALUES ${Prisma.join(batch)}
+            `;
+      log(`Finished batch #${idx + 1} of ids`, 'batch');
+    }
+
+    for (const [idx, batch] of this.batchList(this.relationSqls.assetLanguages, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of asset languages`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+                  INSERT INTO asset_language (asset_id, language_item_code)
+                  VALUES ${Prisma.join(batch)}
+                `;
+      log(`Finished batch #${idx + 1} of asset languages`, 'batch');
+    }
+
+    for (const [idx, batch] of this.batchList(this.relationSqls.manCatLabelRefs, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of mancatlabelrefs`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+                  INSERT INTO man_cat_label_ref (asset_id, man_cat_label_item_code)
+                  VALUES ${Prisma.join(batch)}
+                `;
+      log(`Finished batch #${idx + 1} of mancatlabelrefs`, 'batch');
+    }
+
+    for (const [idx, batch] of this.batchList(this.relationSqls.typeNatRels, BATCH_SIZE).entries()) {
+      log(`Creating batch #${idx + 1} of typeNatRels`, 'batch');
+      await this.destinationPrisma.$executeRaw`
+                  INSERT INTO type_nat_rel (asset_id, nat_rel_item_code)
+                  VALUES ${Prisma.join(batch)}
+                `;
+      log(`Finished batch #${idx + 1} of typeNatRels`, 'batch');
+    }
+  }
+
+  private async createWorkflows() {
+    log(`Create workflows`);
+    const workflowSelection = await this.destinationPrisma.workflowSelection.createManyAndReturn({
+      data: Array.from({ length: this.newAssetToOriginalAsset.size * 2 }, () => ({})),
+      select: { id: true },
+    });
+
+    // for each new asset id, assign this an ID (since workflow.id === asset.assetId), and fetch two ids from the selections
+    const keys = Array.from(this.newAssetToOriginalAsset.keys());
+    const workflows = await this.destinationPrisma.workflow.createManyAndReturn({
+      select: { id: true },
+      data: keys.map((n) => ({
+        id: n,
+        status: 'Draft',
+        assigneeId: this.syncAssignee,
+        reviewId: workflowSelection.shift().id,
+        approvalId: workflowSelection.shift().id,
+      })),
+    });
+
+    await this.destinationPrisma.workflowChange.createMany({
+      data: workflows.map(({ id }) => ({
+        workflowId: id,
+        comment: `Synchronized from EXTERN with original ID ${this.newAssetToOriginalAsset.get(id).originalAssetId}`,
+        fromStatus: 'Published',
+        toStatus: 'Draft',
+        toAssigneeId: this.syncAssignee,
+      })),
+    });
+  }
+
+  private async createAssetSynchronizationRecords(): Promise<Prisma.AssetSynchronizationGetPayload<object>[]> {
+    log('Create synchronization records');
+    return this.destinationPrisma.assetSynchronization.createManyAndReturn({
+      data: Array.from(this.newAssetToOriginalAsset.entries()).map((a) => ({
+        assetId: a[0],
+        originalAssetId: a[1].originalAssetId,
+        originalSgsId: a[1].originalSgsId,
+      })),
+    });
+  }
+}
+
+interface StudyGeometry {
+  id: number;
+  assetId: number;
+  geom: Uint8Array;
+  isRevised: boolean;
+}
+
+type StudGeometryId = StudyGeometry['assetId'];
+
+type StudyGeometryTransfer = Omit<StudyGeometry, 'assetId'>;
+
+type StudyGeometriesPerAsset = Map<StudGeometryId, StudyGeometryTransfer[]>;
+
+interface Geometries {
+  areas: StudyGeometriesPerAsset;
+  locations: StudyGeometriesPerAsset;
+  traces: StudyGeometriesPerAsset;
+}
+
+interface RelationSqls {
+  ids: Prisma.Sql[];
+  assetLanguages: Prisma.Sql[];
+  manCatLabelRefs: Prisma.Sql[];
+  typeNatRels: Prisma.Sql[];
+}
+
+interface AssetToSync {
+  asset: Omit<Asset, 'assetId' | 'sgsId'>;
+  originalAssetId: Asset['assetId'];
+  originalSgsId: Asset['sgsId'];
+  assetFiles: File[];
+  assetContacts: (AssetContact & { contact: Contact })[];
+  manCatLabelRefs: Pick<ManCatLabelRef, 'manCatLabelItemCode'>[];
+  typeNatRels: Pick<TypeNatRel, 'natRelItemCode'>[];
+  ids: Pick<Id, 'id' | 'description'>[];
+  assetLanguages: Pick<AssetLanguage, 'languageItemCode'>[];
 }

--- a/apps/sync-asset-sg/src/main.ts
+++ b/apps/sync-asset-sg/src/main.ts
@@ -29,7 +29,7 @@ switch (config.mode) {
     break;
   case 'extern':
     new SyncExternService(sourcePrisma, destinationPrisma, config)
-      .syncProdAndExtern()
+      .syncExternalToInternal()
       .then(() => log('Export to extern completed'))
       .catch((error) => console.error(error));
     break;

--- a/k8s/swissgeol-sync/secrets.template.yaml
+++ b/k8s/swissgeol-sync/secrets.template.yaml
@@ -1,2 +1,4 @@
-sourceConnectionString:
-destinationConnectionString:
+syncViewSourceConnectionString:
+syncViewDestinationConnectionString:
+syncExternToInternSourceConnectionString:
+syncExternToInternDestinationConnectionString:

--- a/k8s/swissgeol-sync/templates/cronjob.sync-extern-to-intern.yaml
+++ b/k8s/swissgeol-sync/templates/cronjob.sync-extern-to-intern.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}--sync-extern-to-intern
   namespace: {{ .Release.Namespace }}
   annotations:
     keel.sh/policy: force
@@ -18,26 +18,28 @@ spec:
       template:
         spec:
           containers:
-            - name: {{ .Release.Name }}--sync-view
+            - name: {{ .Release.Name }}--sync-extern-to-intern
               image: {{ .Values.image }}
               imagePullPolicy: Always
 
               env:
+                - name: SYNC_ASSIGNEE
+                  value: "{{ .Values.syncExternToIntern.defaultAssignee }}"
                 - name: SOURCE_CONNECTION_STRING
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Release.Name }}-secrets
-                      key: syncViewSourceConnectionString
+                      key: syncExternToInternSourceConnectionString
                 - name: SOURCE_WORKGROUP_IDS
-                  value: "{{ .Values.syncView.sourceAllowedWorkgroupIds }}"
+                  value: "{{ .Values.syncExternToIntern.sourceAllowedWorkgroupIds }}"
                 - name: DESTINATION_CONNECTION_STRING
                   valueFrom:
                     secretKeyRef:
                       name: {{ .Release.Name }}-secrets
-                      key: syncViewDestinationConnectionString
+                      key: syncExternToInternDestinationConnectionString
                 - name: DESTINATION_WORKGROUP_IDS
-                  value: "{{ .Values.syncView.destinationAllowedWorkgroupIds }}"
+                  value: "{{ .Values.syncExternToIntern.destinationAllowedWorkgroupIds }}"
                 - name: MODE
-                  value: {{ .Values.syncView.mode }}
+                  value: {{ .Values.syncExternToIntern.mode }}
           restartPolicy: Never
       backoffLimit: 4

--- a/k8s/swissgeol-sync/templates/secrets.yaml
+++ b/k8s/swissgeol-sync/templates/secrets.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  sourceConnectionString: {{ .Values.sourceConnectionString | quote }}
-  destinationConnectionString: {{ .Values.destinationConnectionString | quote }}
+  syncViewSourceConnectionString: {{ .Values.syncView.sourceConnectionString | quote }}
+  syncViewDestinationConnectionString: {{ .Values.syncView.destinationConnectionString | quote }}
+  syncExternToInternSourceConnectionString: {{ .Values.syncExternToIntern.sourceConnectionString | quote }}
+  syncExternToInternDestinationConnectionString: {{ .Values.syncExternToIntern.destinationConnectionString | quote }}

--- a/k8s/swissgeol-sync/values.template.yaml
+++ b/k8s/swissgeol-sync/values.template.yaml
@@ -1,4 +1,11 @@
-sourceAllowedWorkgroupIds: '1'
-destinationAllowedWorkgroupIds:
 image: 'swissgeol-assets-pipeline:latest'
-mode: 'view' # 'view' or 'extern'
+
+syncView:
+  sourceAllowedWorkgroupIds: '1'
+  destinationAllowedWorkgroupIds:
+  mode: 'view'
+syncExternToIntern:
+  mode: 'extern'
+  sourceAllowedWorkgroupIds: '1'
+  destinationAllowedWorkgroupIds:
+  defaultAssignee: 'marcel.pfiffner@swisstopo.ch'

--- a/libs/persistence/prisma/migrations/20250617054456_add_synchronization_table/migration.sql
+++ b/libs/persistence/prisma/migrations/20250617054456_add_synchronization_table/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "asset_synchronization" (
+    "id" SERIAL NOT NULL,
+    "asset_id" INTEGER NOT NULL,
+    "original_asset_id" INTEGER NOT NULL,
+    "original_sgs_id" INTEGER,
+    "sync_date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "asset_synchronization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "asset_synchronization_asset_id_key" ON "asset_synchronization"("asset_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "asset_synchronization_original_asset_id_key" ON "asset_synchronization"("original_asset_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "asset_synchronization_original_sgs_id_key" ON "asset_synchronization"("original_sgs_id");
+
+-- AddForeignKey
+ALTER TABLE "asset_synchronization" ADD CONSTRAINT "asset_synchronization_asset_id_fkey" FOREIGN KEY ("asset_id") REFERENCES "asset"("asset_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/persistence/prisma/schema.prisma
+++ b/libs/persistence/prisma/schema.prisma
@@ -63,7 +63,20 @@ model Asset {
 
   workflow Workflow?
 
+  synchronization AssetSynchronization?
+
   @@map("asset")
+}
+
+model AssetSynchronization {
+  id         Int            @id @default(autoincrement()) @map("id")
+  asset Asset @relation(fields: [assetId], references: [assetId], onDelete: Cascade)
+  assetId Int @unique  @map("asset_id")
+  originalAssetId Int @unique  @map("original_asset_id")
+  originalSgsId Int? @unique  @map("original_sgs_id")
+  syncDate DateTime @default(now()) @map("sync_date")
+
+  @@map("asset_synchronization")
 }
 
 model Id {


### PR DESCRIPTION
Closes #310 

I optimized it only to a certain degree, because batching it further would require a lot of work to guarantee we do not duplicate stuff and have the proper references (without having to permanently fetch all the data from the database).

See notices on the main function as to what is synced and what is not.

For testing purposes:

1. Set `mode=extern` in env
2. Dump your db and import it as e.g. `postgres_extern`
3. Adjust source and target
4. Run the import service