### PR TITLE
Elastic Search

### DIFF
--- a/apps/server-asset-sg/src/features/assets/assets.module.ts
+++ b/apps/server-asset-sg/src/features/assets/assets.module.ts
@@ -11,6 +11,7 @@ import { AssetSearchController } from '@/features/assets/assets/search/asset-sea
 import { AssetSearchService } from '@/features/assets/assets/search/asset-search.service';
 import { AssetSyncController } from '@/features/assets/assets/sync/asset-sync.controller';
 import { AssetSyncService } from '@/features/assets/assets/sync/asset-sync.service';
+import { SyncOnStartHook } from '@/features/assets/assets/sync/hooks/sync-on-start.hook';
 import { FavoriteRepo } from '@/features/assets/favorites/favorite.repo';
 import { FavoritesController } from '@/features/assets/favorites/favorites.controller';
 import { FileOcrService } from '@/features/assets/files/file-ocr.service';
@@ -35,6 +36,7 @@ import { UsersModule } from '@/features/users/users.module';
     WorkflowController,
   ],
   providers: [
+    SyncOnStartHook,
     provideElasticsearch,
     AssetRepo,
     AssetEditRepo,

--- a/apps/server-asset-sg/src/features/assets/assets/sync/hooks/sync-on-start.hook.ts
+++ b/apps/server-asset-sg/src/features/assets/assets/sync/hooks/sync-on-start.hook.ts
@@ -1,0 +1,11 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { AssetSyncService } from '@/features/assets/assets/sync/asset-sync.service';
+
+@Injectable()
+export class SyncOnStartHook implements OnApplicationBootstrap {
+  constructor(private readonly assetSyncService: AssetSyncService) {}
+  public async onApplicationBootstrap() {
+    await this.assetSyncService.clearSyncFileIfExists();
+    await this.assetSyncService.start();
+  }
+}


### PR DESCRIPTION
Closes #580 

Implemented as restart hook; will trigger on boot.

Reasoning: See comment history, TLDR: k8s approach with init containers has too much overhead.

Drawbacks: _if_ we scale out, this can of course lead to race conditions, but this would be another issue anyway (i.e. if multiple users sync on different shards).