### PR TITLE
Display OCR state in editor

### DIFF
--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -177,6 +177,15 @@ export const deAppTranslations = {
         willBeUploaded: 'Wird hochgeladen werden',
         fileSizeToLarge: 'Die Dateigrösse darf 2 GB nicht überschreiten.',
         uploadedAt: 'Hochgeladen',
+        ocrStatus: 'OCR Status',
+        ocrStatusValues: {
+          willNotBeProcessed: 'nicht berücksichtigt',
+          created: 'registriert',
+          waiting: 'wartet',
+          processing: 'wird prozessiert',
+          error: 'Fehler',
+          success: 'abgeschlossen',
+        },
       },
       usage: {
         tabName: 'Nutzung',

--- a/apps/client-asset-sg/src/app/i18n/en.ts
+++ b/apps/client-asset-sg/src/app/i18n/en.ts
@@ -178,6 +178,15 @@ export const enAppTranslations: AppTranslations = {
         willBeUploaded: 'Will be uploaded',
         fileSizeToLarge: 'File size may not exceed 2GB',
         uploadedAt: 'Uploaded',
+        ocrStatus: 'OCR Status',
+        ocrStatusValues: {
+          willNotBeProcessed: 'will not be processed',
+          created: 'created',
+          waiting: 'waiting',
+          processing: 'processing',
+          error: 'error',
+          success: 'success',
+        },
       },
       usage: {
         tabName: 'Usage',

--- a/apps/client-asset-sg/src/app/i18n/fr.ts
+++ b/apps/client-asset-sg/src/app/i18n/fr.ts
@@ -179,6 +179,15 @@ export const frAppTranslations: AppTranslations = {
         willBeUploaded: 'Sera téléchargé',
         fileSizeToLarge: 'La taille du fichier ne doit pas dépasser 2 Go.',
         uploadedAt: 'Téléchargé',
+        ocrStatus: 'OCR Status',
+        ocrStatusValues: {
+          willNotBeProcessed: 'FR nicht berücksichtigt',
+          created: 'FR registriert',
+          waiting: 'FR wartet',
+          processing: 'FR wird prozessiert',
+          error: 'FR Fehler',
+          success: 'FR abgeschlossen',
+        },
       },
       usage: {
         tabName: 'Utilisation',

--- a/apps/client-asset-sg/src/app/i18n/it.ts
+++ b/apps/client-asset-sg/src/app/i18n/it.ts
@@ -178,6 +178,15 @@ export const itAppTranslations: AppTranslations = {
         willBeUploaded: 'IT Wird hochgeladen werden',
         fileSizeToLarge: 'IT Die Dateigrösse darf 2 GB nicht überschreiten.',
         uploadedAt: 'IT Hochgeladen',
+        ocrStatus: 'IT OCR Status',
+        ocrStatusValues: {
+          willNotBeProcessed: 'IT nicht berücksichtigt',
+          created: 'IT registriert',
+          waiting: 'IT wartet',
+          processing: 'IT wird prozessiert',
+          error: 'IT Fehler',
+          success: 'IT abgeschlossen',
+        },
       },
       usage: {
         tabName: 'IT Nutzung',

--- a/apps/server-asset-sg/src/features/assets/asset-edit/asset-edit.repo.ts
+++ b/apps/server-asset-sg/src/features/assets/asset-edit/asset-edit.repo.ts
@@ -341,6 +341,7 @@ const selectPrismaAsset = selectOnAsset({
           legalDocItemCode: true,
           pageCount: true,
           lastModifiedAt: true,
+          ocrStatus: true,
         },
       },
     },

--- a/apps/server-asset-sg/src/features/assets/asset-edit/models/AssetDetailFromPostgres.ts
+++ b/apps/server-asset-sg/src/features/assets/asset-edit/models/AssetDetailFromPostgres.ts
@@ -22,6 +22,7 @@ export const AssetFileFromPostgres = D.struct({
   legalDocItemCode: D.nullable(LegalDocItemCode),
   pageCount: D.nullable(D.number),
   lastModifiedAt: DT.date,
+  ocrStatus: D.nullable(D.string),
 });
 
 export const AssetFilesFromPostgres = pipe(

--- a/apps/server-asset-sg/src/features/assets/files/file.repo.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.repo.ts
@@ -25,6 +25,7 @@ export class FileRepo
         legalDocItemCode: true,
         pageCount: true,
         lastModifiedAt: true,
+        ocrStatus: true,
       },
     });
     if (entry == null) {
@@ -73,6 +74,7 @@ export class FileRepo
       legalDocItemCode: data.legalDocItemCode,
       pageCount: null, // this is filled (if at all) by postprocessing via OCR
       lastModifiedAt,
+      ocrStatus: data.ocrStatus,
     };
   }
 

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.html
@@ -80,6 +80,16 @@
                   </asset-sg-select>
                 </td>
               </ng-container>
+              <ng-container matColumnDef="ocrStatus">
+                <th mat-header-cell *matHeaderCellDef class="large">
+                  <span translate>edit.tabs.files.ocrStatus</span>
+                </th>
+                <td mat-cell *matCellDef="let control" class="large">
+                  @if (control.value.ocrStatus) {
+                    {{ "edit.tabs.files.ocrStatusValues." + control.value.ocrStatus | translate }}
+                  }
+                </td>
+              </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns" class="table__header"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
             </table>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.ts
@@ -31,7 +31,7 @@ export class AssetEditorFilesComponent implements OnInit, OnDestroy {
   public normalFiles: FormControl<FormAssetFile>[] = [];
 
   protected dataSource: MatTableDataSource<FormControl<FormAssetFile>> = new MatTableDataSource();
-  private readonly COLUMNS = ['select', 'name', 'lastModifiedAt', 'legalDocItemCode'];
+  private readonly COLUMNS = ['select', 'name', 'lastModifiedAt', 'legalDocItemCode', 'ocrStatus'];
   public displayedColumns: string[] = this.COLUMNS.filter((col) => col !== 'legalDocItemCode');
 
   private readonly store = inject(Store);

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/file-drop-zone/file-drop-zone.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/file-drop-zone/file-drop-zone.component.ts
@@ -60,6 +60,7 @@ export class FileDropZoneComponent {
             willBeDeleted: false,
             file: element,
             lastModifiedAt: new Date(),
+            ocrStatus: null,
           },
           { nonNullable: true },
         ),

--- a/libs/shared/src/lib/models/asset-edit.ts
+++ b/libs/shared/src/lib/models/asset-edit.ts
@@ -61,6 +61,7 @@ export const AssetFile = C.struct({
   legalDocItemCode: C.nullable(LegalDocItemCode),
   pageCount: C.nullable(C.number),
   lastModifiedAt: CT.DateFromISOString,
+  ocrStatus: C.nullable(C.string),
 });
 
 export type AssetFile = C.TypeOf<typeof AssetFile>;


### PR DESCRIPTION
Closes #337 

![image](https://github.com/user-attachments/assets/7ffc76eb-8530-4af1-9a07-eb82e53d54da)

I just assumed the values should be translated. Since we use `PatchAsset`, the value cannot be overriden.