### PR TITLE
Bugfix 608: Modal beim Verlassen des Edit-Modus ohne Speicherung funktioniert nicht korrekt

### DIFF
--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -316,6 +316,8 @@ export const deAppTranslations = {
     unsavedChanges: 'Ungespeicherte Änderungen',
     discardChanges: 'Änderungen verwerfen',
     questionDiscardChanges: 'Es gibt ungespeicherte Änderungen. Möchten Sie alle Änderungen speichern?',
+    questionAbortChanges:
+      'Ihre Eingaben sind unvollständig. Das Asset kann in diesem Zustand nicht gespeichert werden.',
     userManagementHeading: 'Benutzer',
     userManagementButton: 'Benutzer verwalten',
     adminInstructionsSyncElasticAssetsHeading: 'Assets mit Elasticsearch synchronisieren',

--- a/apps/client-asset-sg/src/app/i18n/en.ts
+++ b/apps/client-asset-sg/src/app/i18n/en.ts
@@ -315,6 +315,7 @@ export const enAppTranslations: AppTranslations = {
     unsavedChanges: 'Unsaved Changes',
     discardChanges: 'Discard changes',
     questionDiscardChanges: 'There are unsaved changes. Do you want to save all changes?',
+    questionAbortChanges: 'Your edits are currently incomplete. The asset cannot be saved in this state.',
     userManagementHeading: 'Users',
     userManagementButton: 'Manage users',
     adminInstructionsSyncElasticAssetsHeading: 'Synchronize assets with Elasticsearch',

--- a/apps/client-asset-sg/src/app/i18n/fr.ts
+++ b/apps/client-asset-sg/src/app/i18n/fr.ts
@@ -318,6 +318,7 @@ export const frAppTranslations: AppTranslations = {
     discardChanges: 'Annuler les modifications',
     questionDiscardChanges:
       'Il y a des modifications non enregistrées. Souhaitez-vous enregistrer toutes les modifications ?',
+    questionAbortChanges: "Votre saisie est incomplète. L'asset ne peut pas être enregistré dans cet état.",
     userManagementHeading: 'Utilisateurs',
     userManagementButton: 'Gérer les utilisateurs',
     adminInstructionsSyncElasticAssetsHeading: 'Synchroniser les assets avec Elasticsearch',

--- a/apps/client-asset-sg/src/app/i18n/it.ts
+++ b/apps/client-asset-sg/src/app/i18n/it.ts
@@ -317,6 +317,8 @@ export const itAppTranslations: AppTranslations = {
     unsavedChanges: 'IT Ungespeicherte Änderungen',
     discardChanges: 'Änderungen verwerfen',
     questionDiscardChanges: 'IT Es gibt ungespeicherte Änderungen. Möchten Sie alle Änderungen speichern?',
+    questionAbortChanges:
+      'IT Ihre Eingaben sind unvollständig. Das Asset kann in diesem Zustand nicht gespeichert werden.',
     adminInstructionsSyncElasticAssetsHeading: 'IT Assets mit Elasticsearch synchronisieren',
     adminInstructionsSyncElasticAssets:
       'IT Gleicht den Zustand von Elasticsearch mit der Datenbank ab.' +

--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
@@ -427,7 +427,7 @@ export class AssetEditorPageComponent implements OnInit, OnDestroy {
     }
     const dialogRef = this.dialogService.open<ConfirmDialogComponent, ConfirmDialogData>(ConfirmDialogComponent, {
       data: {
-        text: 'edit.questionDiscardChanges',
+        text: this.form.invalid ? 'edit.questionAbortChanges' : 'edit.questionDiscardChanges',
         confirm: 'save',
         isSaveDisabled: this.form.invalid,
       },

--- a/libs/client-shared/src/lib/components/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/client-shared/src/lib/components/confirm-dialog/confirm-dialog.component.ts
@@ -26,11 +26,7 @@ export class ConfirmDialogComponent {
   constructor(
     private readonly dialogRef: MatDialogRef<ConfirmDialogComponent>,
     @Inject(MAT_DIALOG_DATA)
-    public data: {
-      text: string;
-      confirm: string;
-      isSaveDisabled: boolean;
-    },
+    public data: ConfirmDialogData,
   ) {}
 
   public close(confirmed: boolean) {


### PR DESCRIPTION
Resolves #608.

Adds a custom message to the asset edit exit dialog when the form is invalid.