### PR TITLE
Fix broken filters

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -221,7 +221,7 @@ export class AssetSearchService {
       geometryTypes: {
         buckets: AggregationBucket<GeometryType | 'None'>[];
       };
-      manCatLabelItemCodes: {
+      topicCodes: {
         buckets: AggregationBucket[];
       };
       usageCodes: {
@@ -290,7 +290,7 @@ export class AssetSearchService {
       languageCodes: makeAggregation('terms', 'languageCodes'),
       geometryTypes: makeAggregation('terms', 'geometryTypes'),
       kindCodes: makeAggregation('terms', 'kindCodes', 'kindCode'),
-      topicCodes: makeAggregation('terms', 'topicCodes', 'topicCode'),
+      topicCodes: makeAggregation('terms', 'topicCodes'),
       usageCodes: makeAggregation('terms', 'usageCodes', 'usageCode'),
       workgroupIds: makeAggregation('terms', 'workgroupIds', 'workgroupId'),
       minCreatedAt: makeAggregation('min', 'minCreatedAt', 'createdAt'),
@@ -309,7 +309,7 @@ export class AssetSearchService {
       authorIds: aggs.authorIds?.a?.buckets?.map(mapBucket) ?? [],
       languageCodes: aggs.languageCodes?.a?.buckets?.map(mapBucket) ?? [],
       geometryTypes: aggs.geometryTypes?.a?.buckets?.map(mapBucket) ?? [],
-      topicCodes: aggs.manCatLabelItemCodes?.a?.buckets?.map(mapBucket) ?? [],
+      topicCodes: aggs.topicCodes?.a?.buckets?.map(mapBucket) ?? [],
       usageCodes: aggs.usageCodes?.a?.buckets?.map(mapBucket) ?? [],
       workgroupIds: aggs.workgroupIds?.a?.buckets?.map(mapBucket) ?? [],
       createdAt: {
@@ -474,7 +474,7 @@ const mapQueryToElasticDslParts = (
         should: [
           {
             query_string: {
-              query: normalizeFieldQuery(escapeElasticQuery(query.text)),
+              query: normalizeFieldQuery(query.text), // todo assets-639: check how to deal with escape
               fields: scope,
             },
           },
@@ -482,6 +482,7 @@ const mapQueryToElasticDslParts = (
       },
     });
   }
+
   if (query.authorId != null) {
     filters.push({
       term: {

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
@@ -167,14 +167,14 @@ export const selectUsageCodeFilters = selectFilters<AssetSearchUsageCode>('usage
 );
 
 export const selectAssetKindFilters = selectFilters<string>('kindCodes', (data) =>
-  Object.values(data.assetKinds).map((item) => ({
+  Object.values(Array.from(data.assetKinds.values())).map((item) => ({
     name: item.name,
     value: item.code,
   })),
 );
 
 export const selectLanguageFilters = selectFilters<string>('languageCodes', (data) => [
-  ...Object.values(data.languages).map((item) => ({
+  ...Object.values(Array.from(data.languages.values())).map((item) => ({
     name: item.name,
     value: item.code,
   })),
@@ -196,7 +196,7 @@ export const selectGeometryFilters = selectFilters<GeometryType | 'None'>('geome
 ]);
 
 export const selectAssetTopicFilters = selectFilters<string>('topicCodes', (data) =>
-  Object.values(data.assetTopics).map((item) => ({
+  Object.values(Array.from(data.assetTopics.values())).map((item) => ({
     name: item.name,
     value: item.code,
   })),


### PR DESCRIPTION
Fixes the bugs @mPfifi reported in teams (missing filters for topics; non working search terms).

* Missing filters: There was an issue with the rename from `manCatLabels` to `topicCodes`, as well as an issue with items now being parsed as `Map` (which cannot be used directly with `Object.values()`
* Non working search terms: This issue arose because in #579 , `escapeElasticQuery` was reintroduced (which was only present in the deprecated and now-removed `searchOld`): while technically correct, this also prevents @mPfifi's search term (`*tech*`) due to escaped characters. See  #639 for a follow up; this needs further discussion. 