### PR TITLE
Revert changes to regex code

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -603,12 +603,14 @@ const escapeElasticQuery = (query: string): string => {
   return query.replace(/(&&|\|\||!|\(|\)|\{|}|\[|]|\^|"|~|\*|\+|-|=|\?|:|\\|\/)/g, '\\$1');
 };
 
-const normalizeFieldQuery = (query: string): string =>
+const normalizeFieldQuery = (
+  query: string,
+): string => // todo assets-639: check how to deal with escape
   query
-    .replace(/title(_*)public\\:/gi, 'title:')
-    .replace(/title(_*)original\\:/gi, 'originalTitle:')
-    .replace(/contact(_*)ame\\:/gi, 'contactNames:')
-    .replace(/sgs(_*)id\\:/gi, 'sgsId:');
+    .replace(/title(_*)public:/gi, 'title:')
+    .replace(/title(_*)original:/gi, 'originalTitle:')
+    .replace(/contact(_*)ame:/gi, 'contactNames:')
+    .replace(/sgs(_*)id:/gi, 'sgsId:');
 
 /**
  * The state of a multistep asset search.


### PR DESCRIPTION
Reverts more changes introduced to regex parsing in #579 which were now broken due to the removal of `escapeElasticQuery` in #640 .

Followup ticket: #639 