### PR TITLE
Bug/assets 650 fix order of workflowchanges

### DIFF
--- a/apps/server-asset-sg/src/features/assets/workflow/prisma-workflow.ts
+++ b/apps/server-asset-sg/src/features/assets/workflow/prisma-workflow.ts
@@ -42,6 +42,9 @@ export const workflowSelection = satisfy<Prisma.WorkflowSelect>()({
     select: workflowSelectionSelection,
   },
   changes: {
+    orderBy: {
+      createdAt: 'asc',
+    },
     select: {
       fromAssignee: { select: simpleUserSelection },
       toAssignee: { select: simpleUserSelection },

--- a/apps/server-asset-sg/src/features/assets/workflow/workflow.controller.ts
+++ b/apps/server-asset-sg/src/features/assets/workflow/workflow.controller.ts
@@ -4,6 +4,7 @@ import {
   WorkflowChangeData,
   WorkflowChangeDataSchema,
   WorkflowPolicy,
+  WorkflowPublishDataSchema,
   WorkflowSelection,
 } from '@asset-sg/shared/v2';
 import { Controller, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
@@ -62,9 +63,13 @@ export class WorkflowController {
   }
 
   @Post('/publish')
-  async publish(@Param('assetId', ParseIntPipe) assetId: number, @CurrentUser() user: User): Promise<Workflow> {
+  async publish(
+    @ParseBody(WorkflowPublishDataSchema) data: WorkflowPublishDataSchema,
+    @Param('assetId', ParseIntPipe) assetId: number,
+    @CurrentUser() user: User,
+  ): Promise<Workflow> {
     const record = await this.workflowService.find(assetId);
     authorize(WorkflowPolicy, user).canUpdate(record);
-    return this.workflowService.publish(record, user.id);
+    return this.workflowService.publish(record, user.id, data);
   }
 }

--- a/apps/server-asset-sg/src/features/assets/workflow/workflow.service.ts
+++ b/apps/server-asset-sg/src/features/assets/workflow/workflow.service.ts
@@ -7,6 +7,7 @@ import {
   Workflow,
   WorkflowChangeData,
   WorkflowPolicy,
+  WorkflowPublishDataSchema,
   WorkflowSelection,
   WorkflowSelectionCategory,
   WorkflowStatus,
@@ -73,13 +74,13 @@ export class WorkflowService {
     return handleMissing(await this.workflowRepo.approvals.update(workflow.id, approval));
   }
 
-  async publish(workflow: Workflow, creatorId: UserId) {
+  async publish(workflow: Workflow, creatorId: UserId, data: WorkflowPublishDataSchema) {
     if (workflow.status !== WorkflowStatus.Reviewed) {
       throw new HttpException('Cannot publish workflow in current status', HttpStatus.BAD_REQUEST);
     }
     return this.workflowRepo.change(workflow.id, {
       creatorId: creatorId,
-      comment: null,
+      comment: data.comment,
       from: { status: workflow.status, assigneeId: (workflow.assignee?.id ?? null) as string | null },
       to: { status: WorkflowStatus.Published, assigneeId: (workflow.assignee?.id ?? null) as string | null },
     });

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-status/asset-editor-status.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-status/asset-editor-status.component.html
@@ -12,6 +12,6 @@
     (sgcWorkflowReviewChange)="handleReviewChange($event)"
     (sgcWorkflowApprovalChange)="handleApprovalChange($event)"
     (sgcWorkflowChange)="handleWorkflowChange($event)"
-    (sgcWorkflowPublish)="handleWorkflowPublish()"
+    (sgcWorkflowPublish)="handleWorkflowPublish($event)"
   />
 }

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-status/asset-editor-status.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-status/asset-editor-status.component.ts
@@ -7,6 +7,7 @@ import {
   Workflow,
   WorkflowChangeData,
   WorkflowPolicy,
+  WorkflowPublishData,
   WorkflowSelection,
 } from '@asset-sg/shared/v2';
 import { Store } from '@ngrx/store';
@@ -127,11 +128,14 @@ export class AssetEditorStatusComponent implements OnChanges {
     });
   }
 
-  handleWorkflowPublish(): void {
+  handleWorkflowPublish(event: SgcWorkflowChangeEvent): void {
     if (!this.workflow) {
       return;
     }
-    this.assetEditorService.publishAsset(this.workflow.id).subscribe((workflow) => {
+    const data: WorkflowPublishData = {
+      comment: event.detail.changes.comment,
+    };
+    this.assetEditorService.publishAsset(this.workflow.id, data).subscribe((workflow) => {
       this.store.dispatch(
         setWorkflow({
           workflow,

--- a/libs/asset-editor/src/lib/services/asset-editor.service.ts
+++ b/libs/asset-editor/src/lib/services/asset-editor.service.ts
@@ -17,6 +17,7 @@ import {
   UpdateAssetDataSchema,
   Workflow,
   WorkflowChangeData,
+  WorkflowPublishData,
   WorkflowSchema,
   WorkgroupId,
 } from '@asset-sg/shared/v2';
@@ -77,9 +78,9 @@ export class AssetEditorService {
     );
   }
 
-  public publishAsset(id: AssetId): Observable<Workflow> {
+  public publishAsset(id: AssetId, data: WorkflowPublishData): Observable<Workflow> {
     return this.httpClient
-      .post<Workflow>(`/api/assets/${id}/workflow/publish`, null)
+      .post<Workflow>(`/api/assets/${id}/workflow/publish`, data)
       .pipe(map((data) => plainToInstance(WorkflowSchema, data)));
   }
 

--- a/libs/shared/v2/src/lib/models/workflow.ts
+++ b/libs/shared/v2/src/lib/models/workflow.ts
@@ -39,6 +39,8 @@ export interface WorkflowChangeData {
   hasRequestedChanges?: boolean;
 }
 
+export type WorkflowPublishData = Pick<WorkflowChangeData, 'comment'>;
+
 export const UnpublishedWorkflowStatus = [
   WorkflowStatus.Draft,
   WorkflowStatus.InReview,

--- a/libs/shared/v2/src/lib/schemas/workflow.schema.ts
+++ b/libs/shared/v2/src/lib/schemas/workflow.schema.ts
@@ -18,6 +18,7 @@ import {
   Workflow,
   WorkflowChange,
   WorkflowChangeData,
+  WorkflowPublishData,
   WorkflowSelection,
   WorkflowStatus,
 } from '../models/workflow';
@@ -47,6 +48,12 @@ export class WorkflowChangeSchema extends Schema implements WorkflowChange {
 
   @TransformLocalDate()
   createdAt!: LocalDate;
+}
+
+export class WorkflowPublishDataSchema extends Schema implements WorkflowPublishData {
+  @IsString({ message: messageNullableString })
+  @IsNullable()
+  comment!: string | null;
 }
 
 export class WorkflowChangeDataSchema extends Schema implements WorkflowChangeData {


### PR DESCRIPTION
Closes #650 

Basically, the order issue could happen because postgres does not guarantee a deterministic sort order if no `ORDER BY` clause is given. This led _in some occasions_ to a weirdly sorted list when running a `SELECT * FROM workflow_change` and to the consequently misordered list. Hence, we explicitly sort the changes now.

The other issue with the missing comment when publishing was because it was not implemented at all.