### PR TITLE
Fix import for LocalDate

### DIFF
--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
@@ -30,6 +30,7 @@ import {
   isDeepEqual,
   LanguageCode,
   LinkedAsset,
+  LocalDate,
   LocalizedItemCode,
   mapGeometryTypeToStudyType,
   UpdateAssetFileData,
@@ -38,7 +39,6 @@ import {
   WorkflowStatus,
 } from '@asset-sg/shared/v2';
 import { Store } from '@ngrx/store';
-import { LocalDate } from '@swissgeol/ui-core';
 import * as E from 'fp-ts/Either';
 import { filter, map, Observable, Subscription, switchMap, take, tap } from 'rxjs';
 import { EditorMode } from '../../models';


### PR DESCRIPTION
Closes #658 

The reason was a wrong import; `LocalDate` from `swissgeol-core` does have a different behaviour.

@daniel-va I noticed that there is a todo in assets to replace this `LocalDate` version with the one from `swissgeol-core` - however, they results differ. Can you investigate why, is this a bug or expected behaviour? The difference seems to lie in `toString` which uses `pad()` in our local version, but not in the library.

<img width="714" height="77" alt="image" src="https://github.com/user-attachments/assets/40569c22-e170-457f-9da2-d9a26ae0d8d5" />
