### PR TITLE
Bugfix 656: Bestehende Suche geht bei Wechsel auf Tab "Favoriten" verloren

### DIFF
--- a/libs/shared/v2/src/lib/models/asset-search/asset-search-query.ts
+++ b/libs/shared/v2/src/lib/models/asset-search/asset-search-query.ts
@@ -25,5 +25,5 @@ export enum AssetSearchUsageCode {
 
 export type Polygon = LV95[];
 
-export const isEmptySearchQuery = (query: AssetSearchQuery): boolean =>
-  Object.values(query).every((value) => value === undefined || value == false);
+export const isEmptySearchQuery = ({ favoritesOnly: _ignore, ...query }: AssetSearchQuery): boolean =>
+  Object.values(query).every((value) => value === undefined);


### PR DESCRIPTION
Resolves #656