### PR TITLE
Run prisma generate in sync build because we import shared lib which …

### DIFF
--- a/apps/sync-asset-sg/docker/Dockerfile
+++ b/apps/sync-asset-sg/docker/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 RUN --mount=type=secret,id=github_token \
     export GITHUB_TOKEN=$(cat /run/secrets/github_token) \
  && npm install --ignore-scripts \
+ && npm run prisma -- generate \
  && npx nx build sync-asset-sg --configuration=production
 
 # final image build


### PR DESCRIPTION
…uses prisma types