### PR TITLE
Feature 591: Automatische Spracherkennung in assets.swissgeol.ch integrieren

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file.repo.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.repo.ts
@@ -33,6 +33,7 @@ export class FileRepo
   async findOrphans(): Promise<AssetFile[]> {
     const entries = await this.prisma.file.findMany({
       where: { AssetFile: { none: {} } },
+      select: assetFileSelection,
     });
     return entries.map(mapAssetFileFromPrisma);
   }

--- a/apps/server-asset-sg/src/features/assets/files/files.controller.ts
+++ b/apps/server-asset-sg/src/features/assets/files/files.controller.ts
@@ -1,9 +1,7 @@
 import { AssetEditPolicy, AssetFileSchema, LegalDocCode, User } from '@asset-sg/shared/v2';
 import {
   Controller,
-  Delete,
   Get,
-  HttpCode,
   HttpException,
   HttpStatus,
   Param,
@@ -95,20 +93,5 @@ export class FilesController {
       mediaType: file.mimetype,
     });
     return plainToInstance(AssetFileSchema, record);
-  }
-
-  @Delete('/:id')
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async delete(
-    @Param('assetId', ParseIntPipe) assetId: number,
-    @Param('id', ParseIntPipe) id: number,
-    @CurrentUser() user: User,
-  ): Promise<void> {
-    const asset = await this.assetRepo.find(assetId);
-    if (asset == null) {
-      throw new HttpException('not found', HttpStatus.NOT_FOUND);
-    }
-    authorize(AssetEditPolicy, user).canDelete(asset);
-    await this.fileService.delete({ id, assetId: asset.id });
   }
 }

--- a/apps/server-asset-sg/src/features/assets/prisma-asset.ts
+++ b/apps/server-asset-sg/src/features/assets/prisma-asset.ts
@@ -281,18 +281,7 @@ export const mapAssetDataToPrismaCreate = (data: CreateAssetDataWithCreator): Pr
 
 export const mapAssetDataToPrismaUpdate = (id: AssetId, data: UpdateAssetData): Prisma.AssetUpdateInput => ({
   ...mapDataToPrisma(data),
-  assetLanguages: {
-    deleteMany: {
-      assetId: id,
-      languageItemCode: { notIn: data.languageCodes },
-    },
-    createMany: {
-      data: data.languageCodes.map((code) => ({
-        languageItemCode: code,
-      })),
-      skipDuplicates: true,
-    },
-  },
+  assetLanguages: mapAssetLanguagesToPrismaUpdate(id, data.languageCodes),
   typeNatRels: {
     // We can't detect which typeNatRels are already mapped as they use a separate id number which we do not use outside the database.
     // This means we have to delete all rels everytime, and then recreate them.
@@ -434,5 +423,21 @@ export const mapAssetDataToPrismaUpdate = (id: AssetId, data: UpdateAssetData): 
         })),
       skipDuplicates: true,
     },
+  },
+});
+
+export const mapAssetLanguagesToPrismaUpdate = (
+  assetId: AssetId,
+  codes: LanguageCode[],
+): Prisma.AssetLanguageUpdateManyWithoutAssetNestedInput => ({
+  deleteMany: {
+    assetId,
+    languageItemCode: { notIn: codes },
+  },
+  createMany: {
+    data: codes.map((code) => ({
+      languageItemCode: code,
+    })),
+    skipDuplicates: true,
   },
 });

--- a/libs/shared/v2/src/lib/models/asset-file.ts
+++ b/libs/shared/v2/src/lib/models/asset-file.ts
@@ -1,3 +1,5 @@
+import { LanguageCode } from './reference-data';
+
 /**
  * DB: `asset_file`
  */
@@ -120,3 +122,15 @@ export enum FileProcessingState {
   Error = 'Error',
   WillNotBeProcessed = 'WillNotBeProcessed',
 }
+
+export const getLanguageCodesOfPages = (pages: Array<{ languages: SupportedPageLanguage[] }>): Set<LanguageCode> => {
+  return pages.reduce((acc, page) => {
+    for (const lang of page.languages) {
+      acc.add(mapSupportedPageLanguageToCode(lang));
+    }
+    return acc;
+  }, new Set<LanguageCode>());
+};
+
+export const mapSupportedPageLanguageToCode = (language: SupportedPageLanguage): LanguageCode =>
+  language.toUpperCase() as LanguageCode;


### PR DESCRIPTION
Resolves #591.

This PR updates an asset's languages whenever one of its files has been processed or deleted.
- Addition of new languages is handled directly in the `FileExtractionService`.
- Removal of obsolete languages is triggered after updating an asset by checking if any of the files that have been removed in the update should cause the removal of a language on the asset.

Note that this PR also removes the `DELETE /assets/:assetId/files/:id` endpoint. That endpoint represented an alternative way to delete files (aside from `PUT /assets/:assetId`) and would thus have required to manage language removal in two separate locations. As the `DELETE` endpoint is no longer in use (maybe never has been?), I chose to simply delete its code instead of duplicating a feature.

The way language removal is handled is definitely not the cleanest and most performant way, as it requires the asset to be updated first and then runs a second pass over it in order to check which files have been removed. However, handling this differently would require some larger refactorings and probably also reduce readability a bit. Hence, I chose to keep it simple for now.
