### PR TITLE
Fix filestate display and categorization editor

### DIFF
--- a/apps/client-asset-sg/src/app/i18n/de.ts
+++ b/apps/client-asset-sg/src/app/i18n/de.ts
@@ -204,6 +204,7 @@ export const deTranslationMapping = {
           Processing: 'wird prozessiert',
           Error: 'Fehler',
           Success: 'abgeschlossen',
+          NotUploaded: 'nicht hochgeladen',
         },
         pageRanges: {
           title: 'Klassifizierung',

--- a/apps/client-asset-sg/src/app/i18n/en.ts
+++ b/apps/client-asset-sg/src/app/i18n/en.ts
@@ -205,6 +205,7 @@ export const enTranslationMapping: AppTranslationMapping = {
           Processing: 'processing',
           Error: 'error',
           Success: 'success',
+          NotUploaded: 'not uploaded',
         },
         pageRanges: {
           title: 'Classification',

--- a/apps/client-asset-sg/src/app/i18n/fr.ts
+++ b/apps/client-asset-sg/src/app/i18n/fr.ts
@@ -206,6 +206,7 @@ export const frTranslationMapping: AppTranslationMapping = {
           Processing: 'FR wird prozessiert',
           Error: 'FR Fehler',
           Success: 'FR abgeschlossen',
+          NotUploaded: 'FR nicht hochgeladen',
         },
         pageRanges: {
           title: 'Classification',

--- a/apps/client-asset-sg/src/app/i18n/it.ts
+++ b/apps/client-asset-sg/src/app/i18n/it.ts
@@ -205,6 +205,7 @@ export const itTranslationMapping: AppTranslationMapping = {
           Processing: 'IT wird prozessiert',
           Error: 'IT Fehler',
           Success: 'IT abgeschlossen',
+          NotUploaded: 'IT nicht hochgeladen',
         },
         pageRanges: {
           title: 'IT Klassifizierung',

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.html
@@ -89,12 +89,18 @@
                 <span translate>edit.tabs.files.fileProcessingState</span>
               </th>
               <td mat-cell *matCellDef="let control" class="column-ocr-status">
-                @if (control.value.fileProcessingState && control.value.fileProcessingStage) {
-                  {{ control.value.fileProcessingStage }} ({{
-                    "edit.tabs.files.fileProcessingStateValues." + control.value.fileProcessingState | translate
-                  }})
+                @if (this.fileProcessingStates().get(control.value.id); as state) {
+                  @if (state.fileProcessingStage) {
+                    {{ state.fileProcessingStage }} ({{
+                      "edit.tabs.files.fileProcessingStateValues." + state.fileProcessingState | translate
+                    }})
+                  } @else {
+                    {{ "edit.tabs.files.fileProcessingStateValues.WillNotBeProcessed" | translate }}
+                  }
+                } @else if (control.value.id) {
+                  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
                 } @else {
-                  {{ "edit.tabs.files.fileProcessingStateValues.WillNotBeProcessed" | translate }}
+                  {{ "edit.tabs.files.fileProcessingStateValues.NotUploaded" | translate }}
                 }
               </td>
             </ng-container>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.html
@@ -1,5 +1,4 @@
 <!-- todo: typehints on formControlName do not work -->
-<!-- todo: icon -->
 <div class="header">
   <h2 translate>edit.tabs.files.pageRanges.title</h2>
   <sgc-button (click)="recalculateClassification()" color="secondary" translate>
@@ -11,7 +10,7 @@
 <div class="form-wrapper" mat-dialog-content>
   <form #formElement [formGroup]="form">
     <div class="page-range-editor" formArrayName="classifications">
-      @for (group of this.form.controls.classifications.controls; track $index) {
+      @for (group of this.form.controls.classifications.controls; track group) {
         <div [formGroupName]="$index" class="page-range-editor__row">
           <div class="page-range-editor__row__inputs">
             <sgc-button


### PR DESCRIPTION
Closes  #713 

I refactored the whole part because previously, our states were not typesafe (because they are not on the AssetFile type) and because there were a lot of different issues with modifying form values that are not part of the form, get sent via API, can be overridden in the background and what not.

Now, we do have form values and OCR state separate, and we show a nice loading indicator.

Bonus: This also fixes the issue where a newly added file has the "nicht berücksichtigt" status per default.