### PR TITLE
Add streaming API for PDF files

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file-s3.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file-s3.service.ts
@@ -34,12 +34,13 @@ export class FileS3Service {
     );
   }
 
-  async load(name: string): Promise<FileS3 | null> {
+  async load(name: string, range?: string): Promise<FileS3 | null> {
     try {
       const output = await this.client.send(
         new GetObjectCommand({
           Key: this.getKey(name),
           Bucket: this.bucket,
+          Range: range,
         }),
       );
       return {


### PR DESCRIPTION
Closes #735 

To note:

* I just reused our download endpoint, since we only had to add the headers and the range parsing
* As discussed, we do not check for PDF or not; this needs to be handled in the frontend (and if a user decides to hack the frontend; since auth still works, they just break their own client, since PDFjs will fetch the full file)
* I removed the separate file lookup in the database - was this needed? I thought we could avoid having multiple lookups
* Yes, we hit the DB for each (partial) request; I thought about caching it, but honestly, I did some tests and it was ~20-30ms penalty when hitting the database