### PR TITLE
Add dataextraction service account

### DIFF
--- a/k8s/swissgeol-assets/templates/deployment.dataextraction.yaml
+++ b/k8s/swissgeol-assets/templates/deployment.dataextraction.yaml
@@ -17,8 +17,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-dataextraction
     spec:
-      # TODO use dataextraction here once it has a custom role arn
-      serviceAccountName: ocr
+      serviceAccountName: dataextraction
       containers:
       - name: {{ .Release.Name }}-dataextraction
         image: {{ .Values.image_dataextraction }}


### PR DESCRIPTION
I added the corresponding user accounts as `dataextraction_service_account_role` value in the vault, for the following files:

* `dev/assets`
* `int/assets`
* `prod/assets`
* `prod/assets-ext`

Closes #728 