### PR TITLE
Add pdf preview to classification overview

### DIFF
--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/asset-editor-files.component.ts
@@ -173,8 +173,14 @@ export class AssetEditorFilesComponent implements OnInit, OnDestroy, OnChanges {
         PageRangeEditorData,
         PageRangeClassification[]
       >(PageRangeEditorComponent, {
-        data: { classifications: file.pageRangeClassifications, pageCount: file.pageCount ?? 0 }, // todo: pageCount can be 0
-        width: '925px',
+        data: {
+          classifications: file.pageRangeClassifications,
+          pageCount: file.pageCount ?? 0,
+          assetId: this.asset!.id,
+          assetFile: { id: file.id, fileName: file.name },
+        }, // todo: pageCount can be 0
+        width: 'auto',
+        height: '90%',
         autoFocus: false,
       });
 

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.html
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.html
@@ -1,78 +1,98 @@
-<!-- todo: typehints on formControlName do not work -->
-<div class="header">
-  <h2 translate>edit.tabs.files.pageRanges.title</h2>
-  <sgc-button (click)="handleManualRecalculation()" color="secondary" translate>
-    edit.tabs.files.pageRanges.recalculateRanges
-    <sgc-icon name="repeat"></sgc-icon>
-  </sgc-button>
-</div>
-<hr />
-<div class="form-wrapper" mat-dialog-content>
-  <form #formElement [formGroup]="form">
-    <div class="page-range-editor" formArrayName="classifications">
-      @for (group of this.form.controls.classifications.controls; track group) {
-        <div [formGroupName]="$index" class="page-range-editor__row">
-          <div class="page-range-editor__row__inputs">
-            <sgc-button
-              size="normal"
-              variant="icon"
-              color="tertiary"
-              [isTransparent]="true"
-              (click)="removeClassification($index)"
-            >
-              <sgc-icon name="trash"></sgc-icon>
-            </sgc-button>
+<div class="wrapper">
+  <!-- todo: typehints on formControlName do not work -->
+  <div class="editor">
+    <div class="header">
+      <h2 translate>edit.tabs.files.pageRanges.title</h2>
+      <sgc-button (click)="handleManualRecalculation()" color="secondary" translate>
+        edit.tabs.files.pageRanges.recalculateRanges
+        <sgc-icon name="repeat"></sgc-icon>
+      </sgc-button>
+    </div>
+    <hr />
+    <div class="form-wrapper" mat-dialog-content>
+      <form #formElement [formGroup]="form">
+        <div class="page-range-editor" formArrayName="classifications">
+          @for (group of this.form.controls.classifications.controls; track group) {
+            <div [formGroupName]="$index" class="page-range-editor__row">
+              <div class="page-range-editor__row__inputs">
+                <sgc-button
+                  size="normal"
+                  variant="icon"
+                  color="tertiary"
+                  [isTransparent]="true"
+                  (click)="removeClassification($index)"
+                >
+                  <sgc-icon name="trash"></sgc-icon>
+                </sgc-button>
 
-            <asset-sg-select
-              formControlName="categories"
-              [title]="'edit.tabs.files.pageRanges.type' | translate"
-              [values]="categories"
-              [bindKey]="'value'"
-              [bindLabel]="'label'"
-              multiple
-              isRequired
-            />
+                <asset-sg-select
+                  formControlName="categories"
+                  [title]="'edit.tabs.files.pageRanges.type' | translate"
+                  [values]="categories"
+                  [bindKey]="'value'"
+                  [bindLabel]="'label'"
+                  multiple
+                  isRequired
+                />
 
-            <asset-sg-select
-              formControlName="languages"
-              [title]="'edit.tabs.files.pageRanges.language' | translate"
-              [values]="languages"
-              [bindKey]="'value'"
-              [bindLabel]="'label'"
-              multiple
-            />
+                <asset-sg-select
+                  formControlName="languages"
+                  [title]="'edit.tabs.files.pageRanges.language' | translate"
+                  [values]="languages"
+                  [bindKey]="'value'"
+                  [bindLabel]="'label'"
+                  multiple
+                />
 
-            <asset-sg-select
-              formControlName="from"
-              [title]="'edit.tabs.files.pageRanges.pageFrom' | translate"
-              [values]="availablePages"
-              skipTranslate
-            />
+                <asset-sg-select
+                  formControlName="from"
+                  [title]="'edit.tabs.files.pageRanges.pageFrom' | translate"
+                  [values]="availablePages"
+                  skipTranslate
+                />
 
-            <asset-sg-select
-              formControlName="to"
-              [title]="'edit.tabs.files.pageRanges.pageTo' | translate"
-              [values]="availablePages"
-              skipTranslate
-            />
-          </div>
-          @if (group.hasError("toLessThanFrom")) {
-            <div class="page-range-editor__row__error" translate>edit.tabs.files.pageRanges.toLessThanFromError</div>
+                <asset-sg-select
+                  formControlName="to"
+                  [title]="'edit.tabs.files.pageRanges.pageTo' | translate"
+                  [values]="availablePages"
+                  skipTranslate
+                />
+              </div>
+              @if (group.hasError("toLessThanFrom")) {
+                <div class="page-range-editor__row__error" translate>
+                  edit.tabs.files.pageRanges.toLessThanFromError
+                </div>
+              }
+            </div>
           }
         </div>
-      }
+      </form>
+      <div (click)="addClassification()" class="page-range-editor__add-row" role="button">
+        <div class="page-range-editor__add-row__icon">
+          <sgc-icon name="plus"></sgc-icon>
+        </div>
+      </div>
     </div>
-  </form>
-  <div (click)="addClassification()" class="page-range-editor__add-row" role="button">
-    <div class="page-range-editor__add-row__icon">
-      <sgc-icon name="plus"></sgc-icon>
+    <hr />
+    <div class="actions" mat-dialog-actions>
+      <sgc-button (click)="cancel()" color="secondary" translate>cancel</sgc-button>
+      <sgc-button
+        (click)="submit()"
+        [isDisabled]="!form.valid"
+        color="primary"
+        data-testid="save-page-ranges"
+        translate
+      >
+        edit.tabs.files.pageRanges.save
+      </sgc-button>
     </div>
   </div>
-</div>
-<hr />
-<div class="actions" mat-dialog-actions>
-  <sgc-button (click)="cancel()" color="secondary" translate>cancel</sgc-button>
-  <sgc-button (click)="submit()" [isDisabled]="!form.valid" color="primary" data-testid="save-page-ranges" translate>
-    edit.tabs.files.pageRanges.save
-  </sgc-button>
+  <div class="pdf-preview">
+    <asset-sg-pdf-viewer
+      [assetId]="this.initialData.assetId"
+      [assetPdfs]="[this.initialData.assetFile]"
+      [hideCloseButton]="true"
+      [hidePdfSelection]="true"
+    ></asset-sg-pdf-viewer>
+  </div>
 </div>

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.scss
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.scss
@@ -1,89 +1,113 @@
 @use "../../../../styles/variables";
+@use "../../../../styles/mixins";
 
-.header {
-  padding: 24px 24px 16px 24px;
-  display: flex;
-  justify-content: space-between;
-}
+.wrapper {
+  display: grid;
+  grid-template: "content pdf-preview" / minmax(850px, 925px) 560px;
+  height: 100%;
 
-h2,
-hr {
-  margin: 0;
-}
+  & .editor {
+    grid-area: content;
+    min-width: 850px;
 
-.content {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 16px;
-  padding: 24px;
-}
-
-.page-range-editor {
-  display: flex;
-  flex-direction: column;
-  gap: 36px;
-
-  &__row {
-    &__inputs {
-      display: grid;
-      width: 100%;
-      grid-template-columns: 36px 465px minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
-      gap: 16px;
-      align-items: end;
+    h2,
+    hr {
+      margin: 0;
     }
 
-    &__error {
-      color: var(--sgc-color-error);
-      font-size: 12px;
+    & .header {
+      padding: 24px 24px 16px 24px;
       display: flex;
-      justify-content: end;
+      justify-content: space-between;
+      gap: 24px;
+      align-items: center;
+
+      &__title {
+        @include mixins.text-ellipsis;
+        flex: 1;
+        min-width: 0;
+      }
+
+      &__reclassify {
+        flex-shrink: 0;
+      }
+    }
+
+    & .form-wrapper {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      gap: 16px;
+
+      & form {
+        overflow: auto;
+        //padding-bottom: 20px;
+
+        & .page-range-editor {
+          display: flex;
+          flex-direction: column;
+          gap: 36px;
+
+          &__row {
+            &__inputs {
+              display: grid;
+              width: 100%;
+              grid-template-columns: 36px 465px minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+              gap: 16px;
+              align-items: end;
+            }
+
+            &__error {
+              color: var(--sgc-color-error);
+              font-size: 12px;
+              display: flex;
+              justify-content: end;
+            }
+          }
+        }
+      }
+
+      & .page-range-editor__add-row {
+        display: flex;
+        flex-shrink: 0;
+        justify-content: center;
+        width: 100%;
+        border: 1px dashed variables.$cyan-08;
+        padding: 12px 0;
+
+        &__icon {
+          background-color: var(--sgc-color-primary);
+          color: white;
+          padding: 10.5px;
+          border-radius: 50%;
+          display: flex;
+        }
+
+        &:hover {
+          cursor: pointer;
+
+          & .page-range-editor__add-row__icon {
+            background-color: var(--sgc-color-primary--hovered);
+          }
+        }
+
+        &:active {
+          & .page-range-editor__add-row__icon {
+            background-color: var(--sgc-color-primary--pressed);
+          }
+        }
+      }
+    }
+
+    & .actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 16px;
+      padding: 24px;
     }
   }
-}
 
-.page-range-editor__add-row {
-  display: flex;
-  flex-shrink: 0;
-  justify-content: center;
-  width: 100%;
-  border: 1px dashed variables.$cyan-08;
-  padding: 12px 0;
-
-  &__icon {
-    background-color: var(--sgc-color-primary);
-    color: white;
-    padding: 10.5px;
-    border-radius: 50%;
-    display: flex;
-  }
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  &:hover &__icon {
-    background-color: var(--sgc-color-primary--hovered);
-  }
-
-  &:active &__icon {
-    background-color: var(--sgc-color-primary--pressed);
-  }
-}
-
-.form-wrapper {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  gap: 16px;
-
-  form {
-    overflow: auto;
-    padding-bottom: 20px;
+  & .pdf-preview {
+    grid-area: pdf-preview;
   }
 }

--- a/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-tabs/asset-editor-files/page-range-editor/page-range-editor.component.ts
@@ -13,7 +13,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef } from '@angular/material/dialog';
-import { AlertType, SelectComponent, showAlert } from '@asset-sg/client-shared';
+import { AlertType, PdfViewerComponent, PdfViewerFile, SelectComponent, showAlert } from '@asset-sg/client-shared';
 import {
   PageCategory,
   PageClassification,
@@ -29,6 +29,8 @@ import { SgcButton, SgcIcon } from '@swissgeol/ui-core-angular';
 export type PageRangeEditorData = {
   classifications: PageRangeClassification[] | null;
   pageCount: number;
+  assetId: number;
+  assetFile: PdfViewerFile;
 };
 
 type PageClassificationFormGroup = FormGroup<{
@@ -60,6 +62,7 @@ type SelectOption<T> = {
     SelectComponent,
     TranslatePipe,
     SgcIcon,
+    PdfViewerComponent,
   ],
   templateUrl: './page-range-editor.component.html',
   styleUrl: './page-range-editor.component.scss',


### PR DESCRIPTION
Resolves #756 

Since we were told that the PDF preview in the classification is not going to be used a lot, I freestyled an implementation that opens the PDF per default in a slightly enlarged overlay. Doing so took much less time (2 hours) instead of having to rework the whole navigation (or add a hacky subnavigation).

I suggest we merge this and let the team decide if it works like that; if they want a "proper" subpage, we're going to reopen it.