### PR TITLE
Add scaling for Retina or UHD displays in PDF viewer

### DIFF
--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
@@ -81,8 +81,17 @@ export class PdfViewerService implements OnDestroy {
   }
 
   private prepareCanvas(canvas: HTMLCanvasElement, viewport: PageViewport) {
-    canvas.width = viewport.width;
-    canvas.height = viewport.height;
+    const dpr = window.devicePixelRatio || 1;
+
+    canvas.width = viewport.width * dpr;
+    canvas.height = viewport.height * dpr;
+    canvas.style.width = `${viewport.width}px`;
+    canvas.style.height = `${viewport.height}px`;
+
+    const context = canvas.getContext('2d');
+    if (context) {
+      context.scale(dpr, dpr);
+    }
   }
 
   private prepareViewport(page: PDFPageProxy, parentWidth: number, parentHeight: number, zoom: number): PageViewport {


### PR DESCRIPTION
Fixes #752 

The changes are _extremely_ subtle - but still, they _are_ noticeable, especially with digitally rendered PDFs (less so for scans, since they are blurry anyways).

**Before on retina**
<img width="1102" height="1560" alt="image" src="https://github.com/user-attachments/assets/9a6ca078-e889-4db3-a51e-e932ff938739" />

**After on retina**
<img width="1102" height="1560" alt="image" src="https://github.com/user-attachments/assets/c2cb34be-f653-49d3-8703-fbd686d1f032" />
