### PR TITLE
Make assetid searchable again and adjust index mapping

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -42,12 +42,17 @@ export const ASSET_ELASTIC_INDEX = 'swissgeol_asset_asset';
 
 const SEARCH_BATCH_SIZE = 10_000;
 
+/**
+ * Fields that are searchable via specific field queries (e.g. id:1234).
+ * Note that these fields must be mapped as `keyword` in the Elasticsearch mapping (swissgeol_asset_asset.json).
+ */
 const SEARCHABLE_FIELDS: (keyof ElasticsearchAsset)[] = [
   'title',
   'originalTitle',
   'contactNames',
   'sgsId',
   'alternativeIds',
+  'id',
 ];
 
 @Injectable()

--- a/development/init/elasticsearch/mappings/swissgeol_asset_asset.json
+++ b/development/init/elasticsearch/mappings/swissgeol_asset_asset.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "id": {
-      "type": "integer"
+      "type": "keyword"
     },
     "kindCode": {
       "type": "keyword"
@@ -10,6 +10,15 @@
       "type": "integer"
     },
     "contactNames": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "alternativeIds": {
       "type": "text",
       "fields": {
         "keyword": {

--- a/libs/shared/v2/src/lib/models/elasticsearch-asset.ts
+++ b/libs/shared/v2/src/lib/models/elasticsearch-asset.ts
@@ -5,6 +5,11 @@ import { GeometryType } from './geometry';
 import { LocalizedItemCode } from './localized-item';
 import { UserId } from './user';
 
+/**
+ * Corresponds to the index mapping defined in swissgeol_asset_asset.json.
+ *
+ * Note that fields that are searchable (see asset-search.service.ts) must be stored as `keyword`.
+ */
 export interface ElasticsearchAsset {
   id: AssetId;
   title: string;


### PR DESCRIPTION
Before, the search for `id:44440` was implicitly defined and worked by accident. This fix is now explicit, adjusting the index mapping and using the field as keyword.