### PR TITLE
Fix: Only add the asset_main_id, if the corresponding main asset is a…

### DIFF
--- a/apps/sync-asset-sg/src/core/export-to-view.service.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.ts
@@ -367,7 +367,10 @@ export class ExportToViewService {
       const filteredAsset: Prisma.AssetCreateManyInput = {
         ...asset,
         // optional fields for siblings
-        assetMainId: publishData.references ? asset.assetMainId : null,
+        assetMainId:
+          publishData.references && asset.assetMainId && this.publicAssetConfigs.has(asset.assetMainId)
+            ? asset.assetMainId
+            : null,
         // optional fields for legacy
         sgsId: publishData.legacy ? asset.sgsId : null,
         geolDataInfo: publishData.legacy ? asset.geolDataInfo : null,


### PR DESCRIPTION
…lso part of the sync to avoid foreign key constraint violation