### PR TITLE
Register assets for elastic update on workflow changes

### DIFF
--- a/apps/server-asset-sg/src/features/assets/asset.service.ts
+++ b/apps/server-asset-sg/src/features/assets/asset.service.ts
@@ -9,7 +9,7 @@ import {
   AssetData,
   GeometryDetail,
 } from '@asset-sg/shared/v2';
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { forwardRef, HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { PrismaService } from '@/core/prisma.service';
 import { AssetRepo } from '@/features/assets/asset.repo';
 import { FileService } from '@/features/assets/files/file.service';
@@ -22,7 +22,7 @@ export class AssetService {
   constructor(
     private readonly assetRepo: AssetRepo,
     private readonly assetSearchService: AssetSearchService,
-    private readonly workflowService: WorkflowService,
+    @Inject(forwardRef(() => WorkflowService)) private readonly workflowService: WorkflowService,
     private readonly geometryDetailRepo: GeometryDetailRepo,
     private readonly fileService: FileService,
     private readonly prismaService: PrismaService,

--- a/apps/server-asset-sg/src/features/assets/workflow/prisma-workflow.ts
+++ b/apps/server-asset-sg/src/features/assets/workflow/prisma-workflow.ts
@@ -1,11 +1,12 @@
 import {
   LocalDate,
   mapWorkflowStatusFromPrisma,
-  Workflow,
   WorkflowChange,
   WorkflowSelection,
+  WorkflowWithAsset,
 } from '@asset-sg/shared/v2';
 import { Prisma } from '@prisma/client';
+import { assetSelection, parseAssetFromPrisma } from '@/features/assets/prisma-asset';
 import { parseSimpleUser, simpleUserSelection } from '@/features/users/user.repo';
 import { satisfy } from '@/utils/define';
 
@@ -27,7 +28,7 @@ export const workflowSelection = satisfy<Prisma.WorkflowSelect>()({
   id: true,
   asset: {
     select: {
-      workgroupId: true,
+      ...assetSelection,
       creator: { select: simpleUserSelection },
       createdAt: true,
     },
@@ -57,8 +58,9 @@ export const workflowSelection = satisfy<Prisma.WorkflowSelect>()({
   },
 });
 
-export const parseWorkflowFromPrisma = (entry: SelectedWorkflow): Workflow => ({
+export const parseWorkflowFromPrisma = (entry: SelectedWorkflow): WorkflowWithAsset => ({
   id: entry.id,
+  asset: parseAssetFromPrisma(entry.asset),
   hasRequestedChanges: entry.hasRequestedChanges,
   status: mapWorkflowStatusFromPrisma(entry.status),
   assignee: entry.assignee && parseSimpleUser(entry.assignee, entry.asset.workgroupId),

--- a/apps/server-asset-sg/src/features/assets/workflow/workflow.repo.ts
+++ b/apps/server-asset-sg/src/features/assets/workflow/workflow.repo.ts
@@ -1,4 +1,4 @@
-import { AssetId, UserId, Workflow, WorkflowStatus } from '@asset-sg/shared/v2';
+import { AssetId, UserId, Workflow, WorkflowStatus, WorkflowWithAsset } from '@asset-sg/shared/v2';
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/core/prisma.service';
 import { FindRepo } from '@/core/repo';
@@ -17,7 +17,7 @@ export class WorkflowRepo implements FindRepo<Workflow, AssetId> {
     return new WorkflowSelectionRepo(this.prisma, 'approvalWorkflow');
   }
 
-  async find(id: AssetId): Promise<Workflow | null> {
+  async find(id: AssetId): Promise<WorkflowWithAsset | null> {
     const entry = await this.prisma.workflow.findUnique({
       select: workflowSelection,
       where: { id },
@@ -26,7 +26,10 @@ export class WorkflowRepo implements FindRepo<Workflow, AssetId> {
     return entry == null ? null : parseWorkflowFromPrisma(entry);
   }
 
-  async change(id: AssetId, { creatorId, comment, from, to, hasRequestedChanges }: ChangeOptions): Promise<Workflow> {
+  async change(
+    id: AssetId,
+    { creatorId, comment, from, to, hasRequestedChanges }: ChangeOptions,
+  ): Promise<WorkflowWithAsset> {
     const entry = await this.prisma.workflow.update({
       where: { id },
       data: {

--- a/libs/shared/v2/src/lib/models/workflow.ts
+++ b/libs/shared/v2/src/lib/models/workflow.ts
@@ -18,6 +18,10 @@ export interface Workflow extends GenericWorkflow {
   workgroupId: WorkgroupId;
 }
 
+export interface WorkflowWithAsset extends Workflow {
+  asset: Asset;
+}
+
 export type WorkflowSelection = Omit<WorkflowSelectionFromPrisma, 'id'>;
 
 export enum WorkflowSelectionCategory {

--- a/libs/shared/v2/src/lib/schemas/workflow.schema.ts
+++ b/libs/shared/v2/src/lib/schemas/workflow.schema.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -27,115 +27,146 @@ import { IsNullable, messageNullableString } from '../utils/class-validator/is-n
 import { Schema, TransformLocalDate } from './base/schema';
 
 export class WorkflowChangeSchema extends Schema implements WorkflowChange {
+  @Expose()
   @IsString({ message: messageNullableString })
   @IsNullable()
   comment!: string | null;
 
+  @Expose()
   @IsNullable()
   creator!: SimpleUser | null;
 
+  @Expose()
   @IsNullable()
   fromAssignee!: SimpleUser | null;
 
+  @Expose()
   @IsNullable()
   toAssignee!: SimpleUser | null;
 
+  @Expose()
   @IsEnum(WorkflowStatus)
   fromStatus!: WorkflowStatus;
 
+  @Expose()
   @IsEnum(WorkflowStatus)
   toStatus!: WorkflowStatus;
 
+  @Expose()
   @TransformLocalDate()
   createdAt!: LocalDate;
 }
 
 export class WorkflowPublishDataSchema extends Schema implements WorkflowPublishData {
+  @Expose()
   @IsString({ message: messageNullableString })
   @IsNullable()
   comment!: string | null;
 }
 
 export class WorkflowChangeDataSchema extends Schema implements WorkflowChangeData {
+  @Expose()
   @IsString({ message: messageNullableString })
   @IsNullable()
   assigneeId!: UserId | null;
 
+  @Expose()
   @IsString({ message: messageNullableString })
   @IsNullable()
   comment!: string | null;
 
+  @Expose()
   @IsIn(UnpublishedWorkflowStatus)
   status!: UnpublishedWorkflowStatus;
 
+  @Expose()
   @IsOptional()
   @IsBoolean()
   hasRequestedChanges?: boolean;
 }
 
 export class WorkflowSelectionSchema extends Schema implements WorkflowSelection {
+  @Expose()
   @IsBoolean()
   general!: boolean;
 
+  @Expose()
   @IsBoolean()
   normalFiles!: boolean;
 
+  @Expose()
   @IsBoolean()
   legalFiles!: boolean;
 
+  @Expose()
   @IsBoolean()
   authors!: boolean;
 
+  @Expose()
   @IsBoolean()
   initiators!: boolean;
 
+  @Expose()
   @IsBoolean()
   suppliers!: boolean;
 
+  @Expose()
   @IsBoolean()
   references!: boolean;
 
+  @Expose()
   @IsBoolean()
   geometries!: boolean;
 
+  @Expose()
   @IsBoolean()
   legacy!: boolean;
 }
 
 export class WorkflowSchema extends Schema implements Workflow {
+  @Expose()
   @IsNumber()
   id!: AssetId;
 
+  @Expose()
   @IsBoolean()
   hasRequestedChanges!: boolean;
 
+  @Expose()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => WorkflowChangeSchema)
   changes!: WorkflowChangeSchema[];
 
+  @Expose()
   @IsObject()
   @ValidateNested()
   @Type(() => WorkflowSelectionSchema)
   review!: WorkflowSelectionSchema;
 
+  @Expose()
   @IsObject()
   @ValidateNested()
   @Type(() => WorkflowSelectionSchema)
   approval!: WorkflowSelectionSchema;
 
+  @Expose()
   @IsEnum(WorkflowStatus)
   status!: WorkflowStatus;
 
+  @Expose()
   @IsNullable()
   assignee!: SimpleUser | null;
 
+  @Expose()
   @IsNullable()
   creator!: SimpleUser | null;
 
+  @Expose()
   @IsNumber()
   workgroupId!: WorkgroupId;
 
+  @Expose()
   @TransformLocalDate()
   createdAt!: LocalDate;
 }


### PR DESCRIPTION
Fixes #604 

Note: I decided to use the schema-based approach here as well, because it allowed me to simplify everything by using an extended `WorkflowWithAsset` schema (which, in turn, allowed me to fetch the asset directly and pass it onto the Elasticsearch writer). 

I also did not rework the `AssetSearchService.register()` method, but I added a notice about a possible race condition - but this issue has nothing to do with the changes here and could, in theory, also happen in different cases.

See https://github.com/swisstopo/swissgeol-assets-suite/issues/861 for follow-up issue.