### PR TITLE
Reset to draft when a user edits an asset

### DIFF
--- a/apps/server-asset-sg/src/features/assets/asset.service.ts
+++ b/apps/server-asset-sg/src/features/assets/asset.service.ts
@@ -58,7 +58,7 @@ export class AssetService {
 
     const [syncedAsset] = await Promise.all([
       this.fileService.syncAssetWithRemovedFiles(updatedAsset, removedFiles),
-      this.assetSearchService.register(updatedAsset),
+      this.workflowService.handleWorkflowForUpdatedAsset(updatedAsset, user),
       this.workflowService.updateSelectionByChanges(asset, updatedAsset, data.geometries),
     ]);
 


### PR DESCRIPTION
Closes #669 

The message is not translated, as it is a system message similar to the synced asset message - I'll ask Marcel during review, however, and if he'd like them translated, I'll create a follow up issue.