### PR TITLE
Keep resultpanel open if user manually opens it without filters

### DIFF
--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -243,6 +243,13 @@ export class ViewerControllerService {
         return;
       }
       const params = await this.viewerParamsService.readParamsFromUrl();
+
+      // Preserve the results panel state if it was manually toggled by the user
+      const currentResultsState = await firstValueFrom(this.store.select(selectResultsState));
+      if (!isPanelAutomaticallyToggled(currentResultsState)) {
+        params.ui.resultsState = currentResultsState;
+      }
+
       this.isUpdatingStore = true;
       await this.updateStoreByParams(params);
       this.isUpdatingStore = false;


### PR DESCRIPTION
Feedback in #666 

If no filter is selected and the result panel is opened and then switched to favourites, this should keep the panel open.