### PR TITLE
Preserve results panel if no params are present

### DIFF
--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -100,6 +100,12 @@ export class ViewerControllerService {
     } else {
       params = paramsFromUrl;
     }
+
+    // Preserve the results panel state if it was manually toggled by the user
+    if (!isPanelAutomaticallyToggled(paramsFromStore.ui.resultsState)) {
+      params = { ...params, ui: { ...params.ui, resultsState: paramsFromStore.ui.resultsState } };
+    }
+
     loads.push(this.updateStoreByParams(params));
 
     const geometries = await firstValueFrom(this.store.select(selectGeometries));


### PR DESCRIPTION
Edgecase in #666 - this is required since on startup, a different logic takes place (from store).