### PR TITLE
Fix routing on language changes to avoid rerendering UI state

### DIFF
--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -41,7 +41,7 @@ import {
 } from '../state/asset-search/asset-search.selector';
 import { AssetSearchService } from './asset-search.service';
 import { GeometryService } from './geometry.service';
-import { isEmptyViewerParams, ViewerParams, ViewerParamsService } from './viewer-params.service';
+import { areViewerParamsEqual, isEmptyViewerParams, ViewerParams, ViewerParamsService } from './viewer-params.service';
 
 @Injectable({ providedIn: 'root' })
 export class ViewerControllerService {
@@ -256,6 +256,10 @@ export class ViewerControllerService {
         params.ui.resultsState = currentResultsState;
       }
 
+      const currentParams = await this.viewerParamsService.readParamsFromStore();
+      if (areViewerParamsEqual(params, currentParams)) {
+        return;
+      }
       this.isUpdatingStore = true;
       await this.updateStoreByParams(params);
       this.isUpdatingStore = false;

--- a/libs/asset-viewer/src/lib/services/viewer-params.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-params.service.ts
@@ -121,6 +121,16 @@ export const isEmptyViewerParams = (params: ViewerParams): boolean =>
   params.ui.map.y === DEFAULT_MAP_POSITION.y &&
   params.ui.map.z === DEFAULT_MAP_POSITION.z;
 
+export const areViewerParamsEqual = (a: ViewerParams, b: ViewerParams): boolean =>
+  a.assetId === b.assetId &&
+  JSON.stringify(a.query) === JSON.stringify(b.query) &&
+  a.ui.scrollOffsetForResults === b.ui.scrollOffsetForResults &&
+  isPanelOpen(a.ui.filtersState) === isPanelOpen(b.ui.filtersState) &&
+  isPanelOpen(a.ui.resultsState) === isPanelOpen(b.ui.resultsState) &&
+  a.ui.map.x === b.ui.map.x &&
+  a.ui.map.y === b.ui.map.y &&
+  a.ui.map.z === b.ui.map.z;
+
 export interface ViewerParams {
   query: AssetSearchQuery;
   ui: AssetSearchUiState;


### PR DESCRIPTION
Closes #850 

The issue was that a language change triggers a redirect, which in turn triggers (via `NavigationEnd`) the `ViewerControllerService.reactToNavigation()` mode, which then, unconditionally, dispatches store actions (even though nothing store-relevant changed), updates querry and reloads assets (which resets the state). All of this destroys the detail view, rerenders the map position and, in turn, resets the UI.

The fix now checks whether 

* the Panel is open via `isPanelOpen` instead of enum values which are reset when navigation is triggered
* incoming URL parameters are identical _before_ they are sent to state processing; if they are (in the case of a language change), the whole update mechanism is skipped.