### PR TITLE
Reset connections for S3 by adding an explicit socket timeout

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file-s3.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file-s3.service.ts
@@ -129,6 +129,12 @@ const loadS3ClientConfig = (): S3ClientConfig => {
 
     // Disables the client automatically appending the hostname to the bucket name.
     forcePathStyle: true,
+    requestHandler: {
+      // Reduces the default socket timeout to prevent hanging connections in case of network issues or client
+      // disconnects if a request is terminated prematurely. If left out, aborted requests leave sockets occupied
+      // without returning them, leading to an exhaustion of sockets after the default (50 sockets) are taken.
+      socketTimeout: 500,
+    },
   };
 };
 

--- a/apps/server-asset-sg/src/features/assets/files/files.controller.ts
+++ b/apps/server-asset-sg/src/features/assets/files/files.controller.ts
@@ -18,6 +18,7 @@ import {
   HttpCode,
   HttpException,
   HttpStatus,
+  Logger,
   Param,
   ParseBoolPipe,
   ParseIntPipe,
@@ -41,6 +42,8 @@ import { parseEnumFromRequest } from '@/utils/request';
 
 @Controller('/assets/:assetId/files')
 export class FilesController {
+  private readonly logger = new Logger(FilesController.name);
+
   constructor(
     private readonly fileRepo: FileRepo,
     private readonly assetRepo: AssetRepo,
@@ -107,6 +110,11 @@ export class FilesController {
     } else {
       res.status(HttpStatus.OK);
     }
+
+    fileStream.content.on('error', (err) => {
+      this.logger.warn('Error streaming file from S3', { error: err, fileName: file.name });
+    });
+
     fileStream.content.pipe(res);
   }
 


### PR DESCRIPTION
Fixes #876 

Locally, I could no longer reproduce it, i.e. the connections with my test script (generating 60 requests and aborting them immediately) were released properly. Might still ned adjustments, though, hence the added logging.