### PR TITLE
Add auth header conditionally in pdf viewer service if token is prese…

### DIFF
--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
@@ -1,7 +1,10 @@
 import { inject, Injectable, OnDestroy } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Store } from '@ngrx/store';
 import { getDocument, GlobalWorkerOptions, PageViewport, PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist';
 import { PDFPageProxy } from 'pdfjs-dist/types/src/display/api';
 import { SessionStorageService } from '../../services/session-storage.service';
+import { selectIsAnonymousMode } from '../../state/app-shared-state.selectors';
 
 // Worker source for PDF JS. Note that this must match the path that is defined in the builder configuration
 GlobalWorkerOptions.workerSrc = 'assets/pdfjs/pdf.worker.min.mjs';
@@ -11,6 +14,8 @@ export class PdfViewerService implements OnDestroy {
   private loadingTask: PDFDocumentLoadingTask | undefined;
   private pdfDoc: PDFDocumentProxy | undefined;
   private readonly sessionStorageService = inject(SessionStorageService);
+  private readonly store = inject(Store);
+  private readonly isViewApp = toSignal(this.store.select(selectIsAnonymousMode));
 
   async ngOnDestroy() {
     await this.destroyPdfJsWorker();
@@ -34,9 +39,7 @@ export class PdfViewerService implements OnDestroy {
 
     this.loadingTask = getDocument({
       url: `/api/assets/${assetId}/files/${pdfId}`,
-      httpHeaders: {
-        Authorization: `Bearer ${this.sessionStorageService.get('access_token')}`,
-      },
+      httpHeaders: this.getAuthorizationHeader(),
       disableAutoFetch: true,
       disableStream: true,
     });
@@ -104,5 +107,17 @@ export class PdfViewerService implements OnDestroy {
   private async destroyPdfJsWorker() {
     await this.loadingTask?.destroy();
     await this.pdfDoc?.destroy();
+  }
+
+  private getAuthorizationHeader(): Record<string, string> {
+    const accessToken = this.sessionStorageService.get('access_token');
+
+    if (this.isViewApp() || !accessToken) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${accessToken}`,
+    };
   }
 }


### PR DESCRIPTION
Required fix for #828 since this currently overrides the `Authorization` header on all envs - on VIEW, it just adds `Bearer null`, which is wrong in itself.