### PR TITLE
Fix edge case when switching language after resetting filters to keep…

### DIFF
--- a/libs/asset-viewer/src/lib/services/viewer-params.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-params.service.ts
@@ -108,9 +108,9 @@ export class ViewerParamsService {
     });
   }
 
-  private parseFavoritesOnlyFromUrl(): boolean {
+  private parseFavoritesOnlyFromUrl(): boolean | undefined {
     const url = document.location.pathname.split('/', 3);
-    return url.length === 3 && url[2] === 'favorites';
+    return url.length === 3 && url[2] === 'favorites' ? true : undefined;
   }
 }
 


### PR DESCRIPTION
Fixes #850 - yet another edge case.

1. Navigate to the app
2. Zoom in on the map
3. Click "Reset filters" to restore state
4. Open the result table
5. Switch language → **result table closes** (should stay open)

### Root cause

When switching language, `reactToNavigation()` compares URL-derived params with store params via `areViewerParamsEqual`. The comparison uses `JSON.stringify` on the query objects:

- **Store query** (after reset): `{}` → `"{}"`
- **URL query**: `{ favoritesOnly: false }` → `'{"favoritesOnly":false}'`

The mismatch comes from `parseFavoritesOnlyFromUrl()` returning `false` instead of `undefined`. This causes a spurious inequality, which triggers `updateStoreByParams` → `setQuery` → `updateByQuery` → loads 0 results → overrides `resultsState` to `ClosedAutomatically`.

### Fix

Changed `parseFavoritesOnlyFromUrl()` in `viewer-params.service.ts` to return `undefined` instead of `false` when not on the favorites page. Now `JSON.stringify` produces `"{}"` for both sides, `areViewerParamsEqual` correctly returns `true`, and the unnecessary store update cycle is skipped entirely.

All other usages are unaffected since `undefined` is falsy just like `false`.