### PR TITLE
Make text selectable in PDF viewer

### DIFF
--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.component.html
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.component.html
@@ -32,7 +32,7 @@
         ></asset-sg-pdf-viewer-toc>
       </div>
     }
-    <div #pdf class="viewer__page-wrapper" [class.viewer__page-wrapper--is-zoomed]="isZoomed()"></div>
+    <div #pdf class="viewer__page-wrapper" [class.viewer__page-wrapper--is-dragging]="isDragMode()"></div>
 
     <div class="viewer__button-container viewer__navigation">
       <asset-sg-pdf-viewer-navigation

--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.component.scss
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.component.scss
@@ -35,8 +35,21 @@
     justify-content: space-around;
     align-items: center;
 
+    .canvas-wrapper {
+      position: relative;
+    }
+
     canvas {
+      display: block;
+      cursor: text;
+    }
+
+    &.viewer__page-wrapper--is-dragging canvas {
       cursor: grab;
+    }
+
+    &.viewer__page-wrapper--is-dragging .textLayer {
+      pointer-events: none;
     }
   }
 
@@ -98,6 +111,93 @@
     &[data-pdf-page-rotation="270"] {
       transform: rotate(270deg);
       transform-origin: center center;
+    }
+  }
+
+  // PDF.js text layer styles for text selection.
+  // ::ng-deep is required because TextLayer creates child elements via DOM APIs, not Angular.
+  // These rules are a minimal subset of pdfjs-dist/web/pdf_viewer.css for the text layer only.
+  ::ng-deep .textLayer {
+    position: absolute;
+    text-align: initial;
+    inset: 0;
+    overflow: clip;
+    opacity: 1;
+    line-height: 1;
+    -webkit-text-size-adjust: none;
+    -moz-text-size-adjust: none;
+    text-size-adjust: none;
+    forced-color-adjust: none;
+    transform-origin: 0 0;
+    caret-color: CanvasText;
+    z-index: 0;
+
+    // Reset font-weight to match the canvas 2D context default (normal/400) used by TextLayer
+    // for measuring text widths. Without this, inherited font-weight (e.g. 500 from body)
+    // causes spans to render wider than their measured widths, with the error accumulating
+    // over longer text and being more visible at larger font sizes.
+    font-weight: normal;
+
+    // --scale-factor, --total-scale-factor, and --scale-round-x/y are set as inline styles
+    // by the service before TextLayer construction.
+    // --min-font-size is set inline by TextLayer itself.
+    --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
+    --min-font-size-inv: calc(1 / var(--min-font-size));
+
+    :is(span, br) {
+      color: transparent;
+      position: absolute;
+      white-space: pre;
+      cursor: text;
+      transform-origin: 0% 0%;
+    }
+
+    > :not(.markedContent),
+    .markedContent span:not(.markedContent) {
+      z-index: 1;
+
+      --font-height: 0;
+      font-size: calc(var(--text-scale-factor) * var(--font-height));
+
+      --scale-x: 1;
+      --rotate: 0deg;
+      transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
+    }
+
+    .markedContent {
+      display: contents;
+    }
+
+    span[role="img"] {
+      user-select: none;
+      cursor: default;
+    }
+
+    ::-moz-selection {
+      background: rgba(0 0 255 / 0.25);
+      background: color-mix(in srgb, AccentColor, transparent 75%);
+    }
+
+    ::selection {
+      background: rgba(0 0 255 / 0.25);
+      background: color-mix(in srgb, AccentColor, transparent 75%);
+    }
+
+    br::-moz-selection {
+      background: transparent;
+    }
+
+    br::selection {
+      background: transparent;
+    }
+
+    .endOfContent {
+      display: block;
+      position: absolute;
+      inset: 100% 0 0;
+      z-index: 0;
+      cursor: default;
+      user-select: none;
     }
   }
 }

--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.component.ts
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.component.ts
@@ -3,9 +3,9 @@ import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import {
   Component,
-  computed,
   effect,
   ElementRef,
+  HostListener,
   inject,
   input,
   OnDestroy,
@@ -90,7 +90,7 @@ export class PdfViewerComponent implements OnDestroy {
   protected readonly pageCount = signal(-1);
   protected readonly isRendering = signal(true);
   protected readonly zoom = signal(1);
-  protected readonly isZoomed = computed(() => this.zoom() !== 1);
+  protected readonly isDragMode = signal(false);
   protected readonly selectedPdf = signal<PdfViewerFile | undefined>(undefined);
   protected readonly pdfViewerService = inject(PdfViewerService);
   protected readonly maxZoomLevel = MAX_ZOOM_LEVEL;
@@ -114,6 +114,30 @@ export class PdfViewerComponent implements OnDestroy {
   public async ngOnDestroy() {
     for (const dragHandler of this.dragHandlers) {
       dragHandler.dispose();
+    }
+  }
+
+  @HostListener('window:keydown.space', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    if (this.isDragMode()) {
+      return;
+    }
+    event.preventDefault();
+    this.setDragMode(true);
+  }
+
+  @HostListener('window:keyup.space')
+  onKeyUp() {
+    if (!this.isDragMode()) {
+      return;
+    }
+    this.setDragMode(false);
+  }
+
+  private setDragMode(enabled: boolean) {
+    this.isDragMode.set(enabled);
+    for (const dragHandler of this.dragHandlers) {
+      dragHandler.disabled = !enabled;
     }
   }
 
@@ -323,7 +347,10 @@ export class PdfViewerComponent implements OnDestroy {
    * provided, the canvas wrapper is positioned absolutely at that center, which is useful for zooming operations to
    * ensure the zoom focuses on the right area.
    */
-  private createCanvasPlaceholder(pageNum: number, center?: PdfPageWrapperCenter): HTMLCanvasElement {
+  private createCanvasPlaceholder(
+    pageNum: number,
+    center?: PdfPageWrapperCenter,
+  ): { canvas: HTMLCanvasElement; textLayerDiv: HTMLDivElement } {
     const canvasWrapper = this.renderer.createElement('div');
     this.renderer.addClass(canvasWrapper, 'canvas-wrapper');
     if (center) {
@@ -339,18 +366,31 @@ export class PdfViewerComponent implements OnDestroy {
     this.renderer.setAttribute(canvas, DATA_PAGE_NUMBER_ID, pageNum.toString());
     this.renderer.setAttribute(canvas, DATA_PAGE_ROTATION_ID, this.rotation.toString());
     this.renderer.appendChild(canvasWrapper, canvas);
+
+    const textLayerDiv = this.renderer.createElement('div') as HTMLDivElement;
+    this.renderer.addClass(textLayerDiv, 'textLayer');
+    this.renderer.appendChild(canvasWrapper, textLayerDiv);
+
     this.renderer.appendChild(this.pdfElement().nativeElement, canvasWrapper);
 
     const dragHandler = this.cdkDragHandler.createDrag(canvasWrapper);
+    dragHandler.disabled = true;
     this.dragHandlers.add(dragHandler);
-    return canvas;
+    return { canvas, textLayerDiv };
   }
 
   private async renderPageAndCache(pageNum: number, center?: PdfPageWrapperCenter) {
     const parentWidth = this.pdfElement().nativeElement.clientWidth * PDF_RENDERING_MARGIN;
     const parentHeight = this.pdfElement().nativeElement.clientHeight * PDF_RENDERING_MARGIN;
-    const canvas = this.createCanvasPlaceholder(pageNum, center);
-    await this.pdfViewerService.renderPageToCanvas(canvas, pageNum, parentWidth, parentHeight, this.zoom());
+    const { canvas, textLayerDiv } = this.createCanvasPlaceholder(pageNum, center);
+    await this.pdfViewerService.renderPageToCanvas(
+      canvas,
+      textLayerDiv,
+      pageNum,
+      parentWidth,
+      parentHeight,
+      this.zoom(),
+    );
     this.pdfCanvasElements.set(pageNum, canvas);
   }
 }

--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
@@ -1,6 +1,13 @@
 import { inject, Injectable, OnDestroy } from '@angular/core';
-import { getDocument, GlobalWorkerOptions, PageViewport, PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist';
-import { PDFPageProxy } from 'pdfjs-dist/types/src/display/api';
+import {
+  getDocument,
+  GlobalWorkerOptions,
+  PageViewport,
+  PDFDocumentLoadingTask,
+  PDFDocumentProxy,
+  TextLayer,
+} from 'pdfjs-dist';
+import { PDFPageProxy, TextContent } from 'pdfjs-dist/types/src/display/api';
 import { SessionStorageService } from '../../services/session-storage.service';
 
 // Worker source for PDF JS. Note that this must match the path that is defined in the builder configuration
@@ -61,6 +68,7 @@ export class PdfViewerService implements OnDestroy {
 
   public async renderPageToCanvas(
     canvas: HTMLCanvasElement,
+    textLayerDiv: HTMLElement,
     pageNum: number,
     parentWidth: number,
     parentHeight: number,
@@ -78,6 +86,83 @@ export class PdfViewerService implements OnDestroy {
       throw new Error('Could not get 2d context from canvas');
     }
     await page.render({ canvasContext: context, viewport, canvas }).promise;
+    await this.renderTextLayer(page, textLayerDiv, viewport);
+  }
+
+  private async renderTextLayer(page: PDFPageProxy, textLayerDiv: HTMLElement, viewport: PageViewport) {
+    const textContent = await page.getTextContent({ disableNormalization: true });
+    await document.fonts.ready;
+
+    // These CSS variables must be set before constructing TextLayer, because the constructor
+    // calls setLayerDimensions which computes width/height from --total-scale-factor.
+    textLayerDiv.style.setProperty('--scale-factor', viewport.scale.toString());
+    textLayerDiv.style.setProperty('--total-scale-factor', viewport.scale.toString());
+    textLayerDiv.style.setProperty('--scale-round-x', '1px');
+    textLayerDiv.style.setProperty('--scale-round-y', '1px');
+
+    const textLayer = new TextLayer({
+      textContentSource: textContent,
+      container: textLayerDiv,
+      viewport,
+    });
+    await textLayer.render();
+    PdfViewerService.hidePdfjsMeasurementCanvas();
+    this.correctTextLayerScaleX(textLayer, textContent, viewport);
+  }
+
+  /**
+   * PDF.js TextLayer computes --scale-x per span using canvas 2D measureText(), which can produce
+   * different widths than the browser's CSS text layout engine for the same font. This causes spans
+   * to be wider or narrower than the actual rendered text on the canvas.
+   *
+   * This method recomputes --scale-x using actual DOM measurements (getBoundingClientRect) to match
+   * the CSS-rendered span widths to the expected PDF text widths.
+   */
+  private correctTextLayerScaleX(textLayer: TextLayer, textContent: TextContent, viewport: PageViewport) {
+    const textDivs = textLayer.textDivs;
+    const textItems = textContent.items.filter((item) => 'str' in item && 'width' in item);
+
+    const savedTransforms: string[] = [];
+    for (let i = 0; i < textDivs.length && i < textItems.length; i++) {
+      savedTransforms.push(textDivs[i].style.transform);
+      textDivs[i].style.transform = 'none';
+    }
+
+    const measurements: { span: HTMLElement; expectedCssWidth: number; naturalWidth: number }[] = [];
+    for (let i = 0; i < textDivs.length && i < textItems.length; i++) {
+      const item = textItems[i];
+      if (!item.width || !textDivs[i].textContent) {
+        continue;
+      }
+      measurements.push({
+        span: textDivs[i],
+        expectedCssWidth: item.width * viewport.scale,
+        naturalWidth: textDivs[i].getBoundingClientRect().width,
+      });
+    }
+
+    for (let i = 0; i < textDivs.length && i < textItems.length; i++) {
+      textDivs[i].style.transform = savedTransforms[i];
+    }
+    for (const { span, expectedCssWidth, naturalWidth } of measurements) {
+      if (naturalWidth > 0) {
+        span.style.setProperty('--scale-x', (expectedCssWidth / naturalWidth).toString());
+      }
+    }
+  }
+
+  /**
+   * pdfjs TextLayer appends a <canvas class="hiddenCanvasElement"> to document.body
+   * for font measurements. It is never removed. Without hiding it, it adds to the
+   * body's content height and can cause scrollbars.
+   */
+  private static hidePdfjsMeasurementCanvas() {
+    document.querySelectorAll<HTMLElement>('body > .hiddenCanvasElement').forEach((el) => {
+      el.style.position = 'absolute';
+      el.style.width = '0';
+      el.style.height = '0';
+      el.style.overflow = 'hidden';
+    });
   }
 
   private prepareCanvas(canvas: HTMLCanvasElement, viewport: PageViewport) {


### PR DESCRIPTION
Closes #881 

Adds the text selection functionality. Some things were a bit hacky, but they might resolve themselves if we move to continuous scroll.

* Recalculation of spans is needed because the calculation is slightly off; probably due to some CSS interferences from outside; so we add an explicity transform to scale it properly
* Adaptation of PdfJS styles - importing the whole pdf.js CSS would increase bundlesize by 2MB (!); so I extracted those bits that are actually required for the textlayer
* Added space-based panning, to allow for selection at all zoom levels
* Selection behaviour should be identical to the one in pdf.js