### PR TITLE
Feature/assets 722 auth inconsistencies

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/asset-search.controller.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.controller.ts
@@ -55,15 +55,29 @@ export class AssetSearchController {
     query: AssetSearchQuery,
     @CurrentUser() user: User,
   ): Promise<AssetSearchStats> {
+    if (user.isAdmin) {
+      // For admins: get restricted stats (correct totals and filter counts),
+      // then overlay unrestricted workgroup counts for workgroup discovery.
+      const restrictedQuery = { ...query };
+      restrictQueryForUser(restrictedQuery, user);
+      const [restrictedStats, unrestrictedStats] = await Promise.all([
+        this.assetSearchService.aggregate(restrictedQuery, user),
+        this.assetSearchService.aggregate(query, user),
+      ]);
+      return {
+        ...restrictedStats,
+        workgroupIds: unrestrictedStats.workgroupIds,
+      };
+    }
     restrictQueryForUser(query, user);
     return await this.assetSearchService.aggregate(query, user);
   }
 }
 
+/**
+ * Restricts the search query to only include workgroups the user has explicit membership in.
+ */
 export const restrictQueryForUser = (query: AssetSearchQuery, user: User) => {
-  if (user.isAdmin) {
-    return;
-  }
   query.workgroupIds =
     query.workgroupIds == null ? [...user.roles.keys()] : query.workgroupIds.filter((it) => user.roles.has(it));
 };

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.controller.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.controller.ts
@@ -60,7 +60,7 @@ export class AssetSearchController {
   }
 }
 
-const restrictQueryForUser = (query: AssetSearchQuery, user: User) => {
+export const restrictQueryForUser = (query: AssetSearchQuery, user: User) => {
   if (user.isAdmin) {
     return;
   }

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.controller.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.controller.ts
@@ -56,18 +56,11 @@ export class AssetSearchController {
     @CurrentUser() user: User,
   ): Promise<AssetSearchStats> {
     if (user.isAdmin) {
-      // For admins: get restricted stats (correct totals and filter counts),
-      // then overlay unrestricted workgroup counts for workgroup discovery.
-      const restrictedQuery = { ...query };
-      restrictQueryForUser(restrictedQuery, user);
-      const [restrictedStats, unrestrictedStats] = await Promise.all([
-        this.assetSearchService.aggregate(restrictedQuery, user),
-        this.assetSearchService.aggregate(query, user),
-      ]);
-      return {
-        ...restrictedStats,
-        workgroupIds: unrestrictedStats.workgroupIds,
-      };
+      // For admins: restrict stats to their workgroups, but keep workgroup
+      // counts unrestricted so they can discover all workgroups.
+      const unrestrictedWorkgroupQuery = { ...query };
+      restrictQueryForUser(query, user);
+      return await this.assetSearchService.aggregate(query, user, { unrestrictedWorkgroupQuery });
     }
     restrictQueryForUser(query, user);
     return await this.assetSearchService.aggregate(query, user);

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -210,12 +210,6 @@ export class AssetSearchService {
    *
    * @param query The query to match with.
    * @param user The user that is executing the query.
-   */
-  /**
-   * Aggregates the stats over all assets matching a specific {@link AssetSearchQuery}.
-   *
-   * @param query The query to match with.
-   * @param user The user that is executing the query.
    * @param options.unrestrictedWorkgroupQuery If provided, the workgroup aggregation will use this
    *   query instead of the main query. This allows admins to see counts for all workgroups
    *   while other stats remain restricted to their assigned workgroups.

--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -211,7 +211,20 @@ export class AssetSearchService {
    * @param query The query to match with.
    * @param user The user that is executing the query.
    */
-  async aggregate(query: AssetSearchQuery, user: User): Promise<AssetSearchStats> {
+  /**
+   * Aggregates the stats over all assets matching a specific {@link AssetSearchQuery}.
+   *
+   * @param query The query to match with.
+   * @param user The user that is executing the query.
+   * @param options.unrestrictedWorkgroupQuery If provided, the workgroup aggregation will use this
+   *   query instead of the main query. This allows admins to see counts for all workgroups
+   *   while other stats remain restricted to their assigned workgroups.
+   */
+  async aggregate(
+    query: AssetSearchQuery,
+    user: User,
+    options?: { unrestrictedWorkgroupQuery?: AssetSearchQuery },
+  ): Promise<AssetSearchStats> {
     type NestedAggResult<T> = {
       [K in keyof T]: {
         a: T[K];
@@ -256,9 +269,11 @@ export class AssetSearchService {
       operator: 'terms' | 'min' | 'max',
       groupName: string,
       fieldName?: string,
+      queryOverride?: AssetSearchQuery,
     ): AggregationsAggregationContainer => {
       const NUMBER_OF_BUCKETS = 10_000;
-      const { filter } = mapQueryToElasticDslParts({ ...query, [groupName]: undefined }, user);
+      const baseQuery = queryOverride ?? query;
+      const { filter } = mapQueryToElasticDslParts({ ...baseQuery, [groupName]: undefined }, user);
       const field: { field: string; size?: number } = { field: fieldName ?? groupName, size: NUMBER_OF_BUCKETS };
       if (operator !== 'terms') {
         delete field.size;
@@ -308,7 +323,7 @@ export class AssetSearchService {
       kindCodes: makeAggregation('terms', 'kindCodes', 'kindCode'),
       topicCodes: makeAggregation('terms', 'topicCodes'),
       usageCodes: makeAggregation('terms', 'usageCodes', 'usageCode'),
-      workgroupIds: makeAggregation('terms', 'workgroupIds', 'workgroupId'),
+      workgroupIds: makeAggregation('terms', 'workgroupIds', 'workgroupId', options?.unrestrictedWorkgroupQuery),
       minCreatedAt: makeAggregation('min', 'minCreatedAt', 'createdAt'),
       maxCreatedAt: makeAggregation('max', 'maxCreatedAt', 'createdAt'),
       status: makeAggregation('terms', 'status', 'status'),

--- a/apps/server-asset-sg/src/features/geometries/geometries.controller.ts
+++ b/apps/server-asset-sg/src/features/geometries/geometries.controller.ts
@@ -11,6 +11,7 @@ import { Controller, Get } from '@nestjs/common';
 import { Authorize } from '@/core/decorators/authorize.decorator';
 import { CurrentUser } from '@/core/decorators/current-user.decorator';
 import { ParseBody } from '@/core/decorators/parse.decorator';
+import { restrictQueryForUser } from '@/features/assets/search/asset-search.controller';
 import { AssetSearchService } from '@/features/assets/search/asset-search.service';
 
 @Controller('/geometries')
@@ -24,6 +25,7 @@ export class GeometriesController {
     query: AssetSearchQuery,
     @CurrentUser() user: User,
   ): Promise<string> {
+    restrictQueryForUser(query, user);
     const geometries = await this.assetSearchService.search(query, user, { limit: 100_000_000, decode: false });
     const mappedGeometries = mapToGeometry(geometries);
 

--- a/libs/asset-viewer/src/lib/components/asset-search-filter/asset-search-filter.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-search-filter/asset-search-filter.component.html
@@ -2,8 +2,9 @@
   <li *rxFor="let filter of filters; trackBy: 'value'">
     <button
       asset-sg-secondary
-      [disabled]="filter.count === 0 && !filter.isActive"
+      [disabled]="filter.isDisabled || (filter.count === 0 && !filter.isActive)"
       [class.active]="filter.isActive"
+      [class.disabled-with-count]="filter.isDisabled"
       (click)="toggle(filter)"
     >
       {{ filter.name | smartTranslate }} ({{ filter.count }})

--- a/libs/asset-viewer/src/lib/components/asset-search-filter/asset-search-filter.component.scss
+++ b/libs/asset-viewer/src/lib/components/asset-search-filter/asset-search-filter.component.scss
@@ -8,3 +8,7 @@ ul {
   padding: 0;
   list-style: none;
 }
+
+button.disabled-with-count {
+  opacity: 0.5;
+}

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
@@ -83,6 +83,7 @@ const makeFilter = <T>(
     ...filter,
     count,
     queryKey,
+    isDisabled: filter.isDisabled ?? false,
 
     // For filters to be active, they need to have at least one asset that they apply to.
     // Also, if there are currently no filters selected (e.g. in the default search state),
@@ -122,9 +123,10 @@ export const selectFilters = <T extends string>(
 
 export const selectWorkgroupFilters = createSelector(
   fromAppShared.selectWorkgroups,
+  fromAppShared.selectUser,
   selectSearchQuery,
   selectSearchStats,
-  (workgroups, query, stats) => {
+  (workgroups, user, query, stats) => {
     // Create a mapping of workgroups by their id for easier and more performant lookup.
     const workgroupsById = new Map<WorkgroupId, SimpleWorkgroup>();
     for (const workgroup of workgroups) {
@@ -142,6 +144,7 @@ export const selectWorkgroupFilters = createSelector(
       configs.push({
         name: workgroup.name,
         value: workgroup.id,
+        isDisabled: user != null && user.isAdmin && !user.roles.has(workgroup.id),
       });
     }
 
@@ -150,6 +153,7 @@ export const selectWorkgroupFilters = createSelector(
       configs.push({
         name: workgroup.name,
         value: workgroup.id,
+        isDisabled: user != null && user.isAdmin && !user.roles.has(workgroup.id),
       });
     }
 
@@ -250,9 +254,15 @@ export interface Filter<T = string> {
   isActive: boolean;
 
   /**
+   * Whether the filter is disabled and cannot be toggled.
+   * Used for workgroup filters where the admin can see the count but not access the assets.
+   */
+  isDisabled: boolean;
+
+  /**
    * The field of {@link AssetSearchQuery} that contains this filter's values.
    */
   queryKey: keyof AssetSearchQuery;
 }
 
-type FilterConfig<T> = Pick<Filter<T>, 'name' | 'value'>;
+type FilterConfig<T> = Pick<Filter<T>, 'name' | 'value'> & { isDisabled?: boolean };

--- a/libs/shared/v2/src/lib/policies/asset.policy.ts
+++ b/libs/shared/v2/src/lib/policies/asset.policy.ts
@@ -5,7 +5,7 @@ import { Policy } from './base/policy';
 export class AssetPolicy extends Policy<Asset> {
   canShow(value: Asset): boolean {
     // A user can see all assets in all workgroups that they are assigned to.
-    return this.user.isAdmin || this.hasWorkgroup(value.workgroupId);
+    return this.hasWorkgroup(value.workgroupId);
   }
 
   override canCreate(): boolean {


### PR DESCRIPTION
Closes #722 

* Filters geometries by a user's workgroup as well to prevent all datapoints from being visible
* Admins now see all available workgroups in filters, with only those being available for selection that they have the access rights for; however, the actual amount of assets per group is still visible (as request by @mPfifi )