### PR TITLE
Feature/assets 895 sync workgroup bug

### DIFF
--- a/apps/sync-asset-sg/jest.config.ts
+++ b/apps/sync-asset-sg/jest.config.ts
@@ -2,6 +2,7 @@ export default {
   displayName: 'sync-asset-sg',
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['./jest.setup.ts'],
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },

--- a/apps/sync-asset-sg/jest.setup.ts
+++ b/apps/sync-asset-sg/jest.setup.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata';

--- a/apps/sync-asset-sg/src/core/sync-extern.service.spec.ts
+++ b/apps/sync-asset-sg/src/core/sync-extern.service.spec.ts
@@ -1,0 +1,243 @@
+import { SyncConfig } from './config';
+import { SyncExternService } from './sync-extern.service';
+
+// Suppress log output during tests
+jest.mock('./log', () => ({
+  log: jest.fn(),
+}));
+
+const config: SyncConfig = {
+  mode: 'extern',
+  syncAssignee: 'test@test.com',
+  source: { connectionString: 'source', allowedWorkgroupIds: [] },
+  destination: { connectionString: 'destination', allowedWorkgroupIds: [] },
+};
+
+function createMockPrisma(overrides: Record<string, unknown> = {}) {
+  return {
+    asset: { findMany: jest.fn().mockResolvedValue([]), update: jest.fn().mockResolvedValue({}) },
+    assetXAssetY: { findMany: jest.fn().mockResolvedValue([]) },
+    assetSynchronization: { findMany: jest.fn().mockResolvedValue([]) },
+    ...overrides,
+  } as any;
+}
+
+/**
+ * Helper to invoke the private `createSiblings` method on the service.
+ * Sets up `assetsToSync` on the instance and calls the method with the given synchronization records.
+ */
+async function callCreateSiblings(setup: {
+  assetsToSync: Array<{
+    originalAssetId: number;
+    asset: { assetMainId: number | null };
+    children: Array<{ assetId: number }>;
+  }>;
+  assetSynchronizations: Array<{ assetId: number; originalAssetId: number; originalSgsId: number | null }>;
+  existingSiblings: Array<{ assetXId: number; assetYId: number }>;
+  allSynchronisations: Array<{ assetId: number; originalAssetId: number; originalSgsId: number | null }>;
+  assetWorkgroups: Array<{ assetId: number; workgroupId: number }>;
+}) {
+  const sourcePrisma = createMockPrisma({
+    assetXAssetY: { findMany: jest.fn().mockResolvedValue(setup.existingSiblings) },
+  });
+  const destinationPrisma = createMockPrisma({
+    assetSynchronization: { findMany: jest.fn().mockResolvedValue(setup.allSynchronisations) },
+    asset: {
+      findMany: jest.fn().mockResolvedValue(setup.assetWorkgroups),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  });
+
+  const service = new SyncExternService(sourcePrisma, destinationPrisma, config);
+
+  // Populate assetsToSync
+  const assetsToSyncInternal: any[] = (service as any).assetsToSync;
+  for (const a of setup.assetsToSync) {
+    assetsToSyncInternal.push(a);
+  }
+
+  await (service as any).createSiblings(setup.assetSynchronizations);
+
+  return { sourcePrisma, destinationPrisma };
+}
+
+describe('SyncExternService.createSiblings', () => {
+  describe('same-workgroup references', () => {
+    it('should create sibling links when both assets are in the same workgroup', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: null }, children: [] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [{ assetXId: 100, assetYId: 200 }],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 10 }, // same workgroup
+        ],
+      });
+
+      expect(destinationPrisma.asset.update).toHaveBeenCalledWith({
+        where: { assetId: 1 },
+        data: {
+          assetMainId: undefined,
+          siblingXAssets: { create: [{ assetYId: 2 }] },
+        },
+      });
+    });
+
+    it('should set assetMainId when parent is in the same workgroup', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: 200 }, children: [] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 10 }, // same workgroup
+        ],
+      });
+
+      expect(destinationPrisma.asset.update).toHaveBeenCalledWith({
+        where: { assetId: 1 },
+        data: {
+          assetMainId: 2,
+          siblingXAssets: { create: [] },
+        },
+      });
+    });
+
+    it('should set assetMainId on children in the same workgroup', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: null }, children: [{ assetId: 200 }] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 10 },
+        ],
+      });
+
+      // First call: update the asset itself; second call: set parent on child
+      expect(destinationPrisma.asset.update).toHaveBeenCalledTimes(2);
+      expect(destinationPrisma.asset.update).toHaveBeenCalledWith({
+        where: { assetId: 2 },
+        data: { assetMainId: 1 },
+      });
+    });
+  });
+
+  describe('cross-workgroup references', () => {
+    it('should skip sibling links when assets are in different workgroups', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: null }, children: [] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [{ assetXId: 100, assetYId: 200 }],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 20 }, // different workgroup
+        ],
+      });
+
+      expect(destinationPrisma.asset.update).toHaveBeenCalledWith({
+        where: { assetId: 1 },
+        data: {
+          assetMainId: undefined,
+          siblingXAssets: { create: [] }, // no siblings created
+        },
+      });
+    });
+
+    it('should not set assetMainId when parent is in a different workgroup', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: 200 }, children: [] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 20 }, // different workgroup
+        ],
+      });
+
+      expect(destinationPrisma.asset.update).toHaveBeenCalledWith({
+        where: { assetId: 1 },
+        data: {
+          assetMainId: null, // nulled out instead of cross-workgroup reference
+          siblingXAssets: { create: [] },
+        },
+      });
+    });
+
+    it('should skip child assignment when child is in a different workgroup', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: null }, children: [{ assetId: 200 }] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 20 }, // different workgroup
+        ],
+      });
+
+      // Only one update call (for the asset itself), child update is skipped
+      expect(destinationPrisma.asset.update).toHaveBeenCalledTimes(1);
+      expect(destinationPrisma.asset.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({ where: { assetId: 2 } }),
+      );
+    });
+  });
+
+  describe('mixed workgroup scenario', () => {
+    it('should keep same-workgroup siblings and skip cross-workgroup ones', async () => {
+      const { destinationPrisma } = await callCreateSiblings({
+        assetsToSync: [{ originalAssetId: 100, asset: { assetMainId: null }, children: [] }],
+        assetSynchronizations: [{ assetId: 1, originalAssetId: 100, originalSgsId: null }],
+        existingSiblings: [
+          { assetXId: 100, assetYId: 200 },
+          { assetXId: 100, assetYId: 300 },
+          { assetXId: 100, assetYId: 400 },
+        ],
+        allSynchronisations: [
+          { assetId: 1, originalAssetId: 100, originalSgsId: null },
+          { assetId: 2, originalAssetId: 200, originalSgsId: null },
+          { assetId: 3, originalAssetId: 300, originalSgsId: null },
+          { assetId: 4, originalAssetId: 400, originalSgsId: null },
+        ],
+        assetWorkgroups: [
+          { assetId: 1, workgroupId: 10 },
+          { assetId: 2, workgroupId: 10 }, // same
+          { assetId: 3, workgroupId: 20 }, // different
+          { assetId: 4, workgroupId: 10 }, // same
+        ],
+      });
+
+      expect(destinationPrisma.asset.update).toHaveBeenCalledWith({
+        where: { assetId: 1 },
+        data: {
+          assetMainId: undefined,
+          siblingXAssets: { create: [{ assetYId: 2 }, { assetYId: 4 }] }, // asset 3 skipped
+        },
+      });
+    });
+  });
+});

--- a/apps/sync-asset-sg/src/core/sync-extern.service.ts
+++ b/apps/sync-asset-sg/src/core/sync-extern.service.ts
@@ -159,11 +159,25 @@ export class SyncExternService {
       where: { assetXId: { in: this.assetsToSync.map((a) => a.originalAssetId) } },
     });
     const allSynchronisations = await this.destinationPrisma.assetSynchronization.findMany();
+
+    // Fetch workgroupId for all synced assets on destination to prevent cross-workgroup references
+    const syncedAssetIds = allSynchronisations.map((s) => s.assetId);
+    const assetWorkgroups = new Map(
+      (
+        await this.destinationPrisma.asset.findMany({
+          where: { assetId: { in: syncedAssetIds } },
+          select: { assetId: true, workgroupId: true },
+        })
+      ).map((a) => [a.assetId, a.workgroupId]),
+    );
+
     for (const asset of this.assetsToSync) {
       const newAssetId = assetSynchronizations.find((n) => n.originalAssetId === asset.originalAssetId);
       if (newAssetId === undefined) {
         throw new Error(`Could not find new asset id for asset ${asset.originalAssetId}`);
       }
+
+      const currentWorkgroupId = assetWorkgroups.get(newAssetId.assetId);
 
       const assetMainLink = allSynchronisations.find((n) => n.originalAssetId === asset.asset.assetMainId);
       const originalAssetXSiblings = existingSiblings
@@ -173,16 +187,49 @@ export class SyncExternService {
         .filter((n) => originalAssetXSiblings.includes(n.originalAssetId))
         .map((n) => n.assetId);
 
+      // Filter siblings to only include assets in the same workgroup
+      const sameWorkgroupSiblings = newAssetSiblings.filter((siblingId) => {
+        const siblingWorkgroupId = assetWorkgroups.get(siblingId);
+        if (siblingWorkgroupId !== currentWorkgroupId) {
+          log(
+            `Skipping cross-workgroup sibling: asset ${newAssetId.assetId} (wg ${currentWorkgroupId}) -> asset ${siblingId} (wg ${siblingWorkgroupId})`,
+          );
+          return false;
+        }
+        return true;
+      });
+
+      // Only set assetMainId if the parent is in the same workgroup
+      const parentId = assetMainLink?.assetId;
+      const parentWorkgroupId = parentId != null ? assetWorkgroups.get(parentId) : undefined;
+      let safeAssetMainId: number | null | undefined = undefined;
+      if (parentId != null && parentWorkgroupId !== currentWorkgroupId) {
+        log(
+          `Skipping cross-workgroup parent: asset ${newAssetId.assetId} (wg ${currentWorkgroupId}) -> parent ${parentId} (wg ${parentWorkgroupId})`,
+        );
+        safeAssetMainId = null;
+      } else {
+        safeAssetMainId = assetMainLink?.assetId;
+      }
+
       await this.destinationPrisma.asset.update({
         where: { assetId: newAssetId.assetId },
         data: {
-          assetMainId: assetMainLink?.assetId,
-          siblingXAssets: { create: newAssetSiblings.map((n) => ({ assetYId: n })) },
+          assetMainId: safeAssetMainId,
+          siblingXAssets: { create: sameWorkgroupSiblings.map((n) => ({ assetYId: n })) },
         },
       });
       for (const child of asset.children) {
         const syncedChildAsset = allSynchronisations.find((n) => n.originalAssetId === child.assetId);
         if (syncedChildAsset) {
+          // Only set assetMainId on child if it shares the workgroup with the parent
+          const childWorkgroupId = assetWorkgroups.get(syncedChildAsset.assetId);
+          if (childWorkgroupId !== currentWorkgroupId) {
+            log(
+              `Skipping cross-workgroup child: parent ${newAssetId.assetId} (wg ${currentWorkgroupId}) -> child ${syncedChildAsset.assetId} (wg ${childWorkgroupId})`,
+            );
+            continue;
+          }
           await this.destinationPrisma.asset.update({
             where: { assetId: syncedChildAsset.assetId },
             data: {


### PR DESCRIPTION
Fixes #895 

The issue was that the sync job did not check if existing synced assets had their workgroups changed in the meantime; this led to an inconsistent state in the PROD instance where an asset could not be saved as long as these relations were present.