### PR TITLE
Sync workflows in VIEW sync to avoid draft fallback

### DIFF
--- a/apps/server-asset-sg/src/features/assets/prisma-asset.ts
+++ b/apps/server-asset-sg/src/features/assets/prisma-asset.ts
@@ -146,8 +146,8 @@ export const parseAssetFromPrisma = (data: SelectedAsset): Asset => ({
   creatorId: data.creatorId,
   createdAt: LocalDate.fromDate(data.createDate),
   receivedAt: LocalDate.fromDate(data.receiptDate),
-  // In Anonymous Mode, Assets do not have a workflow. The previous nonNullAssertion caused the app to crash (see https://github.com/swisstopo/swissgeol-assets-suite/issues/702)
-  // We now default to 'Draft' in this case, since we never display the Workflowstatus in the Viewer App and the status is irrelevant.
+  // Defensive fallback: the previous nonNullAssertion caused the app to crash (see https://github.com/swisstopo/swissgeol-assets-suite/issues/702)
+  // We default to 'Draft' if the workflow is missing, though this should not happen under normal operation.
   workflowStatus: mapWorkflowStatusFromPrisma(data.workflow?.status ?? 'Draft'),
 });
 

--- a/apps/sync-asset-sg/src/core/export-to-view.service.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.ts
@@ -160,6 +160,8 @@ export class ExportToViewService {
     let result = await this.destinationPrisma.asset.createMany({ data: filteredAssets.assets });
     log(`Created ${result.count} assets.`, 'batch');
 
+    await this.exportWorkflows(assetIds);
+
     result = await this.destinationPrisma.assetContact.createMany({ data: filteredAssets.assetContacts });
     log(`Created ${result.count} assetContacts.`, 'batch');
 
@@ -174,6 +176,24 @@ export class ExportToViewService {
       await this.exportGeometries(batch, 'study_trace');
       log(`Finished batch #${idx + 1} of geometries`, 'batch');
     }
+  }
+
+  /**
+   * Export workflows for the given asset ids.
+   * Copies the WorkflowSelection records (review + approval) first, then the Workflow records,
+   * so that foreign key constraints are satisfied.
+   */
+  private async exportWorkflows(assetIds: number[]) {
+    const workflows = await this.sourcePrisma.workflow.findMany({
+      where: { id: { in: assetIds } },
+      select: { id: true, status: true, hasRequestedChanges: true, reviewId: true, approvalId: true },
+    });
+
+    const selectionIds = workflows.flatMap((w) => [w.reviewId, w.approvalId]);
+    await this.export('workflowSelection', 'id', selectionIds, true);
+
+    const result = await this.destinationPrisma.workflow.createMany({ data: workflows });
+    log(`Created ${result.count} workflows.`, 'batch');
   }
 
   /**


### PR DESCRIPTION
Fixes #899 as hotfix

Also sync workflows to avoid having the default fallback. We still keep the fallback, because the constraints are not (and cannot) be enforced on the DB level.