### PR TITLE
Show results for workgroups without access

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -295,7 +295,7 @@ export class AssetSearchService {
       track_total_hits: true,
     });
     const total = (response.hits.total as SearchTotalHits).value;
-    if (total === 0) {
+    if (total === 0 && options?.unrestrictedWorkgroupQuery === undefined) {
       return {
         total: 0,
         kindCodes: [],
@@ -339,10 +339,13 @@ export class AssetSearchService {
       topicCodes: aggs.topicCodes?.a?.buckets?.map(mapBucket) ?? [],
       usageCodes: aggs.usageCodes?.a?.buckets?.map(mapBucket) ?? [],
       workgroupIds: aggs.workgroupIds?.a?.buckets?.map(mapBucket) ?? [],
-      createdAt: {
-        min: LocalDate.fromDate(new Date(aggs.minCreatedAt.a.value)),
-        max: LocalDate.fromDate(new Date(aggs.maxCreatedAt.a.value)),
-      },
+      createdAt:
+        aggs.minCreatedAt != null && aggs.maxCreatedAt != null
+          ? {
+              min: LocalDate.fromDate(new Date(aggs.minCreatedAt.a.value)),
+              max: LocalDate.fromDate(new Date(aggs.maxCreatedAt.a.value)),
+            }
+          : null,
       status: aggs.status?.a?.buckets?.map(mapBucket) ?? [],
     };
   }


### PR DESCRIPTION
Fixes #722 (additional edge case):

When you searched for something that had results _only_ in a workgroup you don't have access to, we got 0 results due to an early return (because the restricted query returned 0 results).

Now, we added another check that avoids the early return _if_ an unrestrictedQuery is set.