### PR TITLE
#965 layout fixes for search results.

### DIFF
--- a/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.html
@@ -35,7 +35,11 @@
           </ng-container>
           <ng-container matColumnDef="titlePublic">
             <th mat-header-cell *matHeaderCellDef translate>{{ "edit.tabs.references.assetTitlePublic" }}</th>
-            <td mat-cell *matCellDef="let asset">{{ asset.title }}</td>
+            <td mat-cell *matCellDef="let asset">
+              <div class="clamped-cell-content">
+                {{ asset.title }}
+              </div>
+            </td>
           </ng-container>
           <ng-container matColumnDef="assetFormat">
             <th mat-header-cell *matHeaderCellDef translate>{{ "search.kind" }}</th>
@@ -48,46 +52,52 @@
             <th mat-header-cell *matHeaderCellDef translate>{{ "search.topic" }}</th>
             <td mat-cell *matCellDef="let asset">
               @for (topicCode of asset.topicCodes; track topicCode) {
-                <div>
-                  {{ topicCode | reference: "assetTopics" }}
-                </div>
+                <div>{{ topicCode | reference: "assetTopics" }}</div>
               }
             </td>
           </ng-container>
           <ng-container matColumnDef="authors">
             <th mat-header-cell *matHeaderCellDef translate>{{ "contactRoles.author" }}</th>
             <td mat-cell *matCellDef="let asset">
-              @for (contact of asset.contacts; track trackContact(contact)) {
-                @if (contact.role === AssetContactRole.Author) {
-                  <div>{{ contact.id | reference: "contacts" }}</div>
+              <div class="clamped-cell-content">
+                @for (contact of asset.contacts; track trackContact(contact)) {
+                  @if (contact.role === AssetContactRole.Author) {
+                    <div>{{ contact.id | reference: "contacts" }}</div>
+                  }
                 }
-              }
+              </div>
             </td>
           </ng-container>
           <ng-container matColumnDef="initiators">
             <th mat-header-cell *matHeaderCellDef translate>{{ "contactRoles.initiator" }}</th>
             <td mat-cell *matCellDef="let asset">
-              @for (contact of asset.contacts; track trackContact(contact)) {
-                @if (contact.role === AssetContactRole.Initiator) {
-                  <div>{{ contact.id | reference: "contacts" }}</div>
+              <div class="clamped-cell-content">
+                @for (contact of asset.contacts; track trackContact(contact)) {
+                  @if (contact.role === AssetContactRole.Initiator) {
+                    <div>{{ contact.id | reference: "contacts" }}</div>
+                  }
                 }
-              }
+              </div>
             </td>
           </ng-container>
           <ng-container matColumnDef="suppliers">
             <th mat-header-cell *matHeaderCellDef translate>{{ "contactRoles.supplier" }}</th>
             <td mat-cell *matCellDef="let asset">
-              @for (contact of asset.contacts; track trackContact(contact)) {
-                @if (contact.role === AssetContactRole.Supplier) {
-                  <div>{{ contact.id | reference: "contacts" }}</div>
+              <div class="clamped-cell-content">
+                @for (contact of asset.contacts; track trackContact(contact)) {
+                  @if (contact.role === AssetContactRole.Supplier) {
+                    <div>{{ contact.id | reference: "contacts" }}</div>
+                  }
                 }
-              }
+              </div>
             </td>
           </ng-container>
           <ng-container matColumnDef="createDate">
             <th mat-header-cell *matHeaderCellDef translate>{{ "search.createdDate" }}</th>
             <td mat-cell *matCellDef="let asset">
-              {{ asset.createdAt | assetSgDate }}
+              <div class="clamped-cell-content">
+                {{ asset.createdAt | assetSgDate }}
+              </div>
             </td>
           </ng-container>
           <tr mat-header-row *matHeaderRowDef="COLUMNS; sticky: true" class="table__header"></tr>
@@ -106,13 +116,31 @@
     @if (searchQuery.type === SearchType.File) {
       <div class="table-container">
         <table mat-table [dataSource]="fileResultsToDisplay" class="mat-elevation-z8 table">
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let file">
+              <div class="action-buttons">
+                <button asset-sg-primary isIcon (click)="searchForAsset(file.assetId); $event.stopPropagation()">
+                  <svg-icon key="info"></svg-icon>
+                </button>
+              </div>
+            </td>
+          </ng-container>
           <ng-container matColumnDef="fileName">
             <th mat-header-cell *matHeaderCellDef>{{ "search.fileName" | translate }}</th>
-            <td mat-cell *matCellDef="let file">{{ file.fileName }}</td>
+            <td mat-cell *matCellDef="let file">
+              <div class="clamped-cell-content">
+                {{ file.fileName }}
+              </div>
+            </td>
           </ng-container>
           <ng-container matColumnDef="assetTitle">
             <th mat-header-cell *matHeaderCellDef>{{ "edit.tabs.references.assetTitlePublic" | translate }}</th>
-            <td mat-cell *matCellDef="let file">{{ file.assetTitle }}</td>
+            <td mat-cell *matCellDef="let file">
+              <div class="clamped-cell-content">
+                {{ file.assetTitle }}
+              </div>
+            </td>
           </ng-container>
           <ng-container matColumnDef="pages">
             <th mat-header-cell *matHeaderCellDef>{{ "search.textMatch" | translate }}</th>
@@ -129,16 +157,7 @@
               </div>
             </td>
           </ng-container>
-          <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef></th>
-            <td mat-cell *matCellDef="let file">
-              <div class="action-buttons">
-                <button asset-sg-primary isIcon (click)="searchForAsset(file.assetId); $event.stopPropagation()">
-                  <svg-icon key="info"></svg-icon>
-                </button>
-              </div>
-            </td>
-          </ng-container>
+
           <tr mat-header-row *matHeaderRowDef="FILE_COLUMNS; sticky: true" class="table__header"></tr>
           <tr
             clickable

--- a/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.scss
+++ b/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.scss
@@ -77,7 +77,6 @@
       line-clamp: 3;
       overflow: hidden;
       display: -webkit-box;
-      -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
 
       // Limit the cells width to max 350px and break words if longer

--- a/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.scss
+++ b/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.scss
@@ -73,8 +73,17 @@
       height: 40px;
     }
 
-    .mat-column-titlePublic {
+    .clamped-cell-content {
+      line-clamp: 3;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+
+      // Limit the cells width to max 350px and break words if longer
+      // this avoids un-sanitized colum data blowing up table horizontally
       word-wrap: break-word;
+      max-width: 300px;
     }
 
     .selected {

--- a/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.ts
@@ -49,7 +49,7 @@ export class AssetSearchResultsComponent implements OnInit, OnDestroy {
     'createDate',
   ];
 
-  protected readonly FILE_COLUMNS = ['fileName', 'assetTitle', 'pages', 'actions'];
+  protected readonly FILE_COLUMNS = ['actions', 'fileName', 'assetTitle', 'pages'];
 
   public allResults$ = new BehaviorSubject<AssetSearchResultItem[]>([]);
 


### PR DESCRIPTION
Limits width of long texts and clamp height to max 3 lines.
Also moves info-button to the front of document search.
After discussion with @mPfifi , we don't want to strictly avoid horizontal scroll.