### PR TITLE
set fuzzyness of document search to 0

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/search-query.utils.ts
+++ b/apps/server-asset-sg/src/features/assets/search/search-query.utils.ts
@@ -63,7 +63,7 @@ export const mapQueryToElasticDslParts = (
             content: {
               query: query.text,
               operator: 'and',
-              fuzziness: 'AUTO',
+              fuzziness: 0,
             },
           },
         };


### PR DESCRIPTION
Hallo @mPfifi

Ich habe die Anpassung gemach (trivial). Fuzzyness ist jetzt auf 0 gesetzt. D.h. es werden nur noch exakte Wort-matches gefunden. Vorher stand der Wert auf "Auto".

Ich habe lokal mit ein paar Sample-Dokumenten getestet und mir scheint das etwas restriktiv. 
Die Suche nach "geotech" liefert jetzt wirklich nur noch Dokumente mit Wörtern die exakt auf "geotech" lauten. Strings wie "geotechn." (als Abkürzung) werden daher nicht gefunden.
Wenn ich den fuzzyness index auf 1 setze wird "geotechn." gefunen, jedoch noicht "geol.ch" wie es bei "Auto" der Fall war.

Wir können die Fuzzyness gerne bei "0" belassen und schauen wie es sich verhält mit vielen Dokumenten.

Ansonsten kann gerne @stijnvermeeren-swisstopo einen Vorschlag machen. Ich erinnere mich an einen Vortrag den er mal über Fuzzy-Search, rsp. Levenshtein Distanz gehalten hat bei Starmind.

Hier ein paar mögliche andere Werte. Uneducated info i got from AI:

 
 
````
              //
              //   fuzziness: 0         — no edits; only exact token matches after analysis.
              //                          "repot" will NOT match "report". (current setting)
              //
              //   fuzziness: 1         — at most 1 edit per token.
              //                          "repot" matches "report" (1 deletion).
              //                          "Bericht" vs "bericth" matches (1 transposition).
              //                          Short tokens (1-2 chars) are still matched exactly.
              //
              //   fuzziness: 2         — at most 2 edits per token.
              //                          "rpot" would match "report" (2 deletions). Very lax.
              //
              //   fuzziness: 'AUTO'    — (former setting) Elasticsearch picks automatically:
              //                          0 edits for tokens ≤2 chars, 1 edit for 3-5 chars,
              //                          2 edits for tokens >5 chars.
              //
              //   fuzziness: 'AUTO:4,8' — like AUTO but with custom thresholds: 0 edits for
              //                          tokens ≤4 chars, 1 edit for 5-7 chars, 2 edits ≥8.
              //
              // Recommended if some tolerance is desired without the noise of AUTO:
              //   fuzziness: 1
````