### PR TITLE
Bug/assets 977 document indexing failures after pre release

### DIFF
--- a/apps/server-asset-sg/src/features/assets/asset.repo.ts
+++ b/apps/server-asset-sg/src/features/assets/asset.repo.ts
@@ -52,6 +52,7 @@ export class AssetRepo implements Repo<Asset, AssetId, CreateAssetDataWithCreato
       where: ids == null ? undefined : { assetId: { in: ids } },
       take: limit,
       skip: offset,
+      orderBy: { assetId: 'asc' },
       select: assetSelection,
     });
     return await Promise.all(entries.map((it) => parseAssetFromPrisma(it)));

--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -222,7 +222,7 @@ export class FileService {
         data: { fulltextContent: content as unknown as Prisma.JsonArray },
       });
     } catch (e) {
-      this.logger.warn('Failed to load fulltext content from S3', { fileId, error: e });
+      // this.logger.warn('Failed to load fulltext content from S3', { fileId, error: e });
     }
   }
 
@@ -247,7 +247,7 @@ export class FileService {
         yield { pageNumber: i, text };
       }
     } finally {
-      await doc?.loadingTask.destroy();
+      doc?.destroy();
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -222,7 +222,7 @@ export class FileService {
         data: { fulltextContent: content as unknown as Prisma.JsonArray },
       });
     } catch (e) {
-      // this.logger.warn('Failed to load fulltext content from S3', { fileId, error: e });
+      this.logger.warn('Failed to load fulltext content from S3', { fileId, error: e });
     }
   }
 
@@ -247,7 +247,7 @@ export class FileService {
         yield { pageNumber: i, text };
       }
     } finally {
-      doc?.destroy();
+      await doc?.destroy();
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   Asset,
   AssetFile,
@@ -26,6 +27,12 @@ import { FileS3Service, SaveFileS3Options } from '@/features/assets/files/file-s
 import { CreateFileData, FileIdentifier, FileRepo } from '@/features/assets/files/file.repo';
 import { PdfMetadataService } from '@/features/assets/files/pdf-metadata.service';
 import { mapAssetLanguagesToPrismaUpdate } from '@/features/assets/prisma-asset';
+
+// eval('require') bypasses webpack's static require analysis so the path is resolved at runtime by Node.js.
+
+const STANDARD_FONT_DATA_URL =
+  path.join(path.dirname((eval('require') as NodeRequire).resolve('pdfjs-dist/package.json')), 'standard_fonts') +
+  path.sep;
 
 @Injectable()
 export class FileService {
@@ -224,6 +231,7 @@ export class FileService {
     try {
       doc = await getDocument({
         url: presignedUrl,
+        standardFontDataUrl: STANDARD_FONT_DATA_URL,
         disableAutoFetch: true,
         disableStream: false,
       }).promise;
@@ -239,7 +247,7 @@ export class FileService {
         yield { pageNumber: i, text };
       }
     } finally {
-      doc?.destroy();
+      await doc?.loadingTask.destroy();
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
@@ -83,7 +83,7 @@ export class PdfMetadataService {
       throw new Error(`PDF metadata extraction failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       // Ensure PDF document is properly destroyed to free memory
-      await doc?.loadingTask.destroy();
+      doc?.destroy();
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
@@ -1,7 +1,14 @@
+import * as path from 'path';
 import { PageDimension } from '@asset-sg/shared/v2';
 import { Injectable, Logger } from '@nestjs/common';
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api';
+
+// eval('require') bypasses webpack's static require analysis so the path is resolved at runtime by Node.js.
+
+const STANDARD_FONT_DATA_URL =
+  path.join(path.dirname((eval('require') as NodeRequire).resolve('pdfjs-dist/package.json')), 'standard_fonts') +
+  path.sep;
 
 @Injectable()
 export class PdfMetadataService {
@@ -23,6 +30,7 @@ export class PdfMetadataService {
       // Load the PDF document without fetching all pages
       doc = await getDocument({
         url: fileUrl,
+        standardFontDataUrl: STANDARD_FONT_DATA_URL,
         disableAutoFetch: true,
         disableStream: false,
       }).promise;
@@ -75,7 +83,7 @@ export class PdfMetadataService {
       throw new Error(`PDF metadata extraction failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       // Ensure PDF document is properly destroyed to free memory
-      await doc?.destroy();
+      await doc?.loadingTask.destroy();
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
@@ -83,7 +83,7 @@ export class PdfMetadataService {
       throw new Error(`PDF metadata extraction failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       // Ensure PDF document is properly destroyed to free memory
-      doc?.destroy();
+      await doc?.destroy();
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/search/asset-search-writer.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search-writer.service.ts
@@ -12,6 +12,7 @@ import { BulkOperationContainer } from '@elastic/elasticsearch/lib/api/types';
 import { PrismaClient } from '@prisma/client';
 import { plainToInstance } from 'class-transformer';
 import {
+  chunkBulkOperations,
   fetchContactNamesForAsset,
   fetchFavoredByUserIdsForAsset,
   fetchGeometryMetadataForAsset,
@@ -24,6 +25,7 @@ import { GeometryRepo } from '@/features/geometries/geometry.repo';
 import { ProcessQueue } from '@/utils/process-queue';
 
 const QUEUE_SIZE = 10;
+const BULK_CHUNK_SIZE = 200;
 
 export class AssetSearchWriterService {
   private eager?: Promise<SharedEagerData | null>;
@@ -53,11 +55,13 @@ export class AssetSearchWriterService {
         .then();
     }
     await processQueue.waitForIdle();
-    await this.elastic.bulk({
-      index: this.options.index,
-      refresh: this.options.shouldRefresh,
-      operations,
-    });
+    for (const chunk of chunkBulkOperations(operations, BULK_CHUNK_SIZE)) {
+      await this.elastic.bulk({
+        index: this.options.index,
+        refresh: this.options.shouldRefresh,
+        operations: chunk,
+      });
+    }
   }
 
   private async mapAssetToElastic(asset: Asset): Promise<ElasticsearchAsset> {

--- a/apps/server-asset-sg/src/features/assets/search/file-search-writer.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/file-search-writer.service.ts
@@ -15,6 +15,7 @@ import {
 import { transformJsonToFulltextContent } from '@asset-sg/shared/v2';
 import { Client as ElasticsearchClient } from '@elastic/elasticsearch';
 import { BulkOperationContainer } from '@elastic/elasticsearch/lib/api/types';
+import { Logger } from '@nestjs/common';
 import { Prisma, PrismaClient } from '@prisma/client';
 import { plainToInstance } from 'class-transformer';
 import {
@@ -34,6 +35,7 @@ import { ProcessQueue } from '@/utils/process-queue';
 const QUEUE_SIZE = 10;
 
 export class FileSearchWriterService {
+  private readonly logger = new Logger(FileSearchWriterService.name);
   private eager?: Promise<SharedEagerData | null>;
 
   constructor(
@@ -243,7 +245,16 @@ export class FileSearchWriterService {
     for (let i = 0; i < assets.length; i++) {
       const asset = assets[i];
       await processQueue.add(async () => {
-        operationsByAsset[i] = await this.mapAssetFilesToElastic(asset);
+        try {
+          operationsByAsset[i] = await this.mapAssetFilesToElastic(asset);
+        } catch (error) {
+          this.logger.error('Failed to index files for asset in elastic, skipping', {
+            assetId: asset.id,
+            assetTitle: asset.title,
+            fileIds: asset.files.map((f) => f.id),
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       });
     }
     await processQueue.waitForIdle();

--- a/apps/server-asset-sg/src/features/assets/search/file-search-writer.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/file-search-writer.service.ts
@@ -21,6 +21,7 @@ import { plainToInstance } from 'class-transformer';
 import {
   buildFavoritesMap,
   buildGeometryMetadataMap,
+  chunkBulkOperations,
   fetchContactNamesForAsset,
   fetchFavoredByUserIdsForAsset,
   fetchGeometryMetadataForAsset,
@@ -33,6 +34,7 @@ import { GeometryRepo } from '@/features/geometries/geometry.repo';
 import { ProcessQueue } from '@/utils/process-queue';
 
 const QUEUE_SIZE = 10;
+const BULK_CHUNK_SIZE = 200;
 
 export class FileSearchWriterService {
   private readonly logger = new Logger(FileSearchWriterService.name);
@@ -217,11 +219,13 @@ export class FileSearchWriterService {
       return;
     }
 
-    await this.elastic.bulk({
-      index: this.options.index,
-      refresh: this.options.shouldRefresh,
-      operations,
-    });
+    for (const chunk of chunkBulkOperations(operations, BULK_CHUNK_SIZE)) {
+      await this.elastic.bulk({
+        index: this.options.index,
+        refresh: this.options.shouldRefresh,
+        operations: chunk,
+      });
+    }
   }
 
   async writeAssetFiles(oneOrMore: Asset | Asset[]): Promise<void> {
@@ -269,11 +273,13 @@ export class FileSearchWriterService {
       return;
     }
 
-    await this.elastic.bulk({
-      index: this.options.index,
-      refresh: this.options.shouldRefresh,
-      operations: allOperations,
-    });
+    for (const chunk of chunkBulkOperations(allOperations, BULK_CHUNK_SIZE)) {
+      await this.elastic.bulk({
+        index: this.options.index,
+        refresh: this.options.shouldRefresh,
+        operations: chunk,
+      });
+    }
   }
 
   async deleteByAssetId(assetId: AssetId): Promise<void> {

--- a/apps/server-asset-sg/src/features/assets/search/search-writer.utils.ts
+++ b/apps/server-asset-sg/src/features/assets/search/search-writer.utils.ts
@@ -91,6 +91,18 @@ export function buildFavoritesMap(records: Array<{ assetId: AssetId; userId: Use
   return mapping;
 }
 
+/**
+ * Splits a flat bulk operations array (alternating header/document pairs) into chunks.
+ * Each chunk contains at most `chunkSize` document pairs (i.e., `chunkSize * 2` array items).
+ */
+export function chunkBulkOperations<T>(operations: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < operations.length; i += chunkSize * 2) {
+    chunks.push(operations.slice(i, i + chunkSize * 2));
+  }
+  return chunks;
+}
+
 export function buildGeometryMetadataMap(
   geometries: Array<{ assetId: AssetId; type: GeometryType; center: { x: number; y: number } }>,
 ): Map<AssetId, GeometryMetadata> {

--- a/apps/server-asset-sg/src/features/assets/sync/atomic-progress.service.ts
+++ b/apps/server-asset-sg/src/features/assets/sync/atomic-progress.service.ts
@@ -54,8 +54,13 @@ export abstract class AtomicProgressService<T extends object> {
 
     await writeProgress(0);
     setTimeout(async () => {
-      await this.sync(writeProgress, options);
-      await rm(this.syncFile);
+      try {
+        await this.sync(writeProgress, options);
+      } catch (error) {
+        this.logger.error('Sync failed with an unhandled error', error);
+      } finally {
+        await rm(this.syncFile);
+      }
     });
   }
 

--- a/apps/server-asset-sg/src/features/assets/sync/file-fulltext-sync.service.ts
+++ b/apps/server-asset-sg/src/features/assets/sync/file-fulltext-sync.service.ts
@@ -76,16 +76,27 @@ export class FileFulltextSyncService extends AtomicProgressService<FileFulltextS
 
     let offset = 0;
     while (true) {
-      this.logger.debug('Indexing file fulltext content.', {
-        total,
-        offset,
-        progress: Number((offset / total).toFixed(2)),
-      });
       const records = await this.assetRepo.list({ limit: 1000, offset });
       if (records.length === 0) {
         break;
       }
-      await fileWriter.writeAssetFiles(records);
+      const firstAssetId = records[0].id;
+      const lastAssetId = records[records.length - 1].id;
+      this.logger.debug('Indexing file fulltext content.', {
+        total,
+        offset,
+        progress: Number((offset / total).toFixed(2)),
+        assetIdRange: `${firstAssetId}–${lastAssetId}`,
+      });
+      try {
+        await fileWriter.writeAssetFiles(records);
+      } catch (error) {
+        this.logger.error('Failed to write file index for batch, continuing with next batch', {
+          offset,
+          assetIdRange: `${firstAssetId}–${lastAssetId}`,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       offset += records.length;
       await writeProgress(progressOffset + Math.min(offset / total, 1) * progressScale);
     }

--- a/apps/server-asset-sg/src/utils/process-queue.ts
+++ b/apps/server-asset-sg/src/utils/process-queue.ts
@@ -14,25 +14,28 @@ export class ProcessQueue {
   }
 
   /**
-   * Registers a new tasks to be run.
+   * Registers a new task to be run.
+   * If the task throws, the error propagates through the returned Promise.
+   * The queue continues processing subsequent tasks regardless.
    *
    * @param run The task to run.
    */
   add(run: () => void | Promise<void>): Promise<void> {
     if (this.active.size < this.quantity) {
-      return new Promise((resolve) => {
-        const process: Process = { run, resolve };
-        this.run(process).then();
+      return new Promise((resolve, reject) => {
+        const process: Process = { run, resolve, reject };
+        this.run(process);
       });
     }
-    return new Promise((resolve) => {
-      const process: Process = { run, resolve };
+    return new Promise((resolve, reject) => {
+      const process: Process = { run, resolve, reject };
       this.buffer.push(process);
     });
   }
 
   /**
    * Returns a promise that resolves when the queue has no more tasks to run.
+   * Individual task failures do not cause this to reject.
    */
   async waitForIdle(): Promise<void> {
     while (true) {
@@ -40,7 +43,7 @@ export class ProcessQueue {
         return;
       }
       if (this.active.size > 0) {
-        await Promise.all(this.active.values());
+        await Promise.allSettled(this.active.values());
       } else {
         await sleep(1);
       }
@@ -49,6 +52,7 @@ export class ProcessQueue {
 
   /**
    * Runs a task. Automatically continues to run any queued tasks afterward.
+   * Resolves or rejects the outer Promise (from `add()`) based on the task outcome.
    *
    * @param process The task to run.
    * @private
@@ -59,23 +63,16 @@ export class ProcessQueue {
       const promise = result instanceof Promise ? result : Promise.resolve();
       this.active.set(process, promise);
       await promise;
+      process.resolve();
+    } catch (error) {
+      process.reject(error);
     } finally {
-      this.finalize(process);
-    }
-  }
-
-  /**
-   * Resolves a finished process, and runs the next task in the queue, if present.
-   *
-   * @param process The task to resolve.
-   * @private
-   */
-  private finalize(process: Process): void {
-    this.active.delete(process);
-    process.resolve();
-    const next = this.buffer.shift();
-    if (next !== undefined) {
-      this.run(next).then();
+      // Resolves a finished process, and runs the next task in the queue, if present.
+      this.active.delete(process);
+      const next = this.buffer.shift();
+      if (next !== undefined) {
+        this.run(next);
+      }
     }
   }
 }
@@ -83,4 +80,5 @@ export class ProcessQueue {
 interface Process {
   run(): void | Promise<void>;
   resolve(): void;
+  reject(error: unknown): void;
 }

--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
@@ -397,7 +397,6 @@ export class PdfViewerService implements OnDestroy {
 
   private async destroyPdfJsWorker() {
     await this.loadingTask?.destroy();
-    await this.pdfDoc?.destroy();
   }
 
   private getAuthorizationHeader(): Record<string, string> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "jsonwebtoken": "^9.0.0",
         "jwk-to-pem": "^2.0.5",
         "ol": "^7.2.2",
-        "pdfjs-dist": "^6.0.227",
+        "pdfjs-dist": "^5.4.296",
         "prisma": "^6.7.0",
         "proj4": "^2.11.0",
         "query-string": "^8.1.0",
@@ -10479,9 +10479,9 @@
       ]
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
-      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -10495,23 +10495,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "1.0.0",
-        "@napi-rs/canvas-darwin-arm64": "1.0.0",
-        "@napi-rs/canvas-darwin-x64": "1.0.0",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
-        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
-        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
-        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
-        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
-        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
-        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
-        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
-      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
       "cpu": [
         "arm64"
       ],
@@ -10529,9 +10529,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
       "cpu": [
         "arm64"
       ],
@@ -10549,9 +10549,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
       "cpu": [
         "x64"
       ],
@@ -10569,9 +10569,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
-      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
       "cpu": [
         "arm"
       ],
@@ -10589,9 +10589,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
-      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
       "cpu": [
         "arm64"
       ],
@@ -10612,9 +10612,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
-      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
       ],
@@ -10635,9 +10635,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
-      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
       "cpu": [
         "riscv64"
       ],
@@ -10658,9 +10658,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
-      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
       "cpu": [
         "x64"
       ],
@@ -10681,9 +10681,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
-      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
       ],
@@ -10704,9 +10704,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
-      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
       "cpu": [
         "arm64"
       ],
@@ -10724,9 +10724,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
-      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
       "cpu": [
         "x64"
       ],
@@ -39656,15 +39656,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.0.227",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
-      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+      "version": "5.7.284",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
+      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^1.0.0"
+        "@napi-rs/canvas": "^0.1.100"
       }
     },
     "node_modules/pend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "jsonwebtoken": "^9.0.0",
         "jwk-to-pem": "^2.0.5",
         "ol": "^7.2.2",
-        "pdfjs-dist": "^5.4.296",
+        "pdfjs-dist": "^6.0.227",
         "prisma": "^6.7.0",
         "proj4": "^2.11.0",
         "query-string": "^8.1.0",
@@ -10479,9 +10479,9 @@
       ]
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.88.tgz",
-      "integrity": "sha512-/p08f93LEbsL5mDZFQ3DBxcPv/I4QG9EDYRRq1WNlCOXVfAHBTHMSVMwxlqG/AtnSfUr9+vgfN7MKiyDo0+Weg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -10495,23 +10495,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.88",
-        "@napi-rs/canvas-darwin-arm64": "0.1.88",
-        "@napi-rs/canvas-darwin-x64": "0.1.88",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.88",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.88",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.88",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.88",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.88",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.88",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.88",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.88"
+        "@napi-rs/canvas-android-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-x64": "1.0.0",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.88.tgz",
-      "integrity": "sha512-KEaClPnZuVxJ8smUWjV1wWFkByBO/D+vy4lN+Dm5DFH514oqwukxKGeck9xcKJhaWJGjfruGmYGiwRe//+/zQQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
       "cpu": [
         "arm64"
       ],
@@ -10529,9 +10529,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.88.tgz",
-      "integrity": "sha512-Xgywz0dDxOKSgx3eZnK85WgGMmGrQEW7ZLA/E7raZdlEE+xXCozobgqz2ZvYigpB6DJFYkqnwHjqCOTSDGlFdg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
       "cpu": [
         "arm64"
       ],
@@ -10549,9 +10549,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.88.tgz",
-      "integrity": "sha512-Yz4wSCIQOUgNucgk+8NFtQxQxZV5NO8VKRl9ePKE6XoNyNVC8JDqtvhh3b3TPqKK8W5p2EQpAr1rjjm0mfBxdg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
       "cpu": [
         "x64"
       ],
@@ -10569,9 +10569,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.88.tgz",
-      "integrity": "sha512-9gQM2SlTo76hYhxHi2XxWTAqpTOb+JtxMPEIr+H5nAhHhyEtNmTSDRtz93SP7mGd2G3Ojf2oF5tP9OdgtgXyKg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
       "cpu": [
         "arm"
       ],
@@ -10589,9 +10589,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.88.tgz",
-      "integrity": "sha512-7qgaOBMXuVRk9Fzztzr3BchQKXDxGbY+nwsovD3I/Sx81e+sX0ReEDYHTItNb0Je4NHbAl7D0MKyd4SvUc04sg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
       "cpu": [
         "arm64"
       ],
@@ -10612,9 +10612,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.88.tgz",
-      "integrity": "sha512-kYyNrUsHLkoGHBc77u4Unh067GrfiCUMbGHC2+OTxbeWfZkPt2o32UOQkhnSswKd9Fko/wSqqGkY956bIUzruA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
       "cpu": [
         "arm64"
       ],
@@ -10635,9 +10635,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.88.tgz",
-      "integrity": "sha512-HVuH7QgzB0yavYdNZDRyAsn/ejoXB0hn8twwFnOqUbCCdkV+REna7RXjSR7+PdfW0qMQ2YYWsLvVBT5iL/mGpw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
       "cpu": [
         "riscv64"
       ],
@@ -10658,11 +10658,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.88.tgz",
-      "integrity": "sha512-hvcvKIcPEQrvvJtJnwD35B3qk6umFJ8dFIr8bSymfrSMem0EQsfn1ztys8ETIFndTwdNWJKWluvxztA41ivsEw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -10678,11 +10681,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.88.tgz",
-      "integrity": "sha512-eSMpGYY2xnZSQ6UxYJ6plDboxq4KeJ4zT5HaVkUnbObNN6DlbJe0Mclh3wifAmquXfrlgTZt6zhHsUgz++AK6g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10698,9 +10704,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.88.tgz",
-      "integrity": "sha512-qcIFfEgHrchyYqRrxsCeTQgpJZ/GqHiqPcU/Fvw/ARVlQeDX1VyFH+X+0gCR2tca6UJrq96vnW+5o7buCq+erA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
       "cpu": [
         "arm64"
       ],
@@ -10718,9 +10724,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.88.tgz",
-      "integrity": "sha512-ROVqbfS4QyZxYkqmaIBBpbz/BQvAR+05FXM5PAtTYVc0uyY8Y4BHJSMdGAaMf6TdIVRsQsiq+FG/dH9XhvWCFQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
       "cpu": [
         "x64"
       ],
@@ -39650,15 +39656,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.4.530",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
-      "integrity": "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q==",
+      "version": "6.0.227",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
+      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.16.0 || >=22.3.0"
+        "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.84"
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/pend": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jsonwebtoken": "^9.0.0",
     "jwk-to-pem": "^2.0.5",
     "ol": "^7.2.2",
-    "pdfjs-dist": "^5.4.296",
+    "pdfjs-dist": "^6.0.227",
     "prisma": "^6.7.0",
     "proj4": "^2.11.0",
     "query-string": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jsonwebtoken": "^9.0.0",
     "jwk-to-pem": "^2.0.5",
     "ol": "^7.2.2",
-    "pdfjs-dist": "^6.0.227",
+    "pdfjs-dist": "^5.4.296",
     "prisma": "^6.7.0",
     "proj4": "^2.11.0",
     "query-string": "^8.1.0",

--- a/scripts/s3-file-sync/swissgeol-assets-s3-sync.mjs
+++ b/scripts/s3-file-sync/swissgeol-assets-s3-sync.mjs
@@ -70,10 +70,12 @@ import {
   ListObjectsV2Command,
   DeleteObjectsCommand,
   DeleteObjectCommand,
+  GetObjectCommand,
   PutObjectCommand,
   CopyObjectCommand,
   HeadObjectCommand,
   CreateMultipartUploadCommand,
+  UploadPartCommand,
   UploadPartCopyCommand,
   CompleteMultipartUploadCommand,
   AbortMultipartUploadCommand,
@@ -115,6 +117,9 @@ function parseArgs(argv) {
     workgroups: null, // null = all workgroups
     deleteDestFiles: false,
     region: "eu-central-1",
+    endpoint: null, // custom S3 endpoint for destination (e.g. http://localhost:9000 for local MinIO)
+    destAccessKey: process.env.DEST_ACCESS_KEY_ID ?? null,
+    destSecretKey: process.env.DEST_SECRET_ACCESS_KEY ?? null,
     dryRun: false,
   };
 
@@ -148,6 +153,24 @@ function parseArgs(argv) {
       case "--region":
         args.region = argv[++i];
         break;
+      case "--endpoint":
+        args.endpoint = argv[++i];
+        break;
+      case "--dest-access-key":
+        args.destAccessKey = argv[++i];
+        break;
+      case "--dest-secret-key":
+        args.destSecretKey = argv[++i];
+        break;
+      case "--endpoint":
+        args.endpoint = argv[++i];
+        break;
+      case "--dest-access-key":
+        args.destAccessKey = argv[++i];
+        break;
+      case "--dest-secret-key":
+        args.destSecretKey = argv[++i];
+        break;
       case "--dry-run":
         args.dryRun = true;
         break;
@@ -164,6 +187,16 @@ function parseArgs(argv) {
   if (missing.length > 0) {
     const flags = missing.map((k) => `--${k.replace(/([A-Z])/g, "-$1").toLowerCase()}`);
     console.error(`❌ Error: missing required argument(s): ${flags.join(", ")}\n`);
+    printHelp();
+    process.exit(1);
+  }
+
+  if (args.endpoint && (!args.destAccessKey || !args.destSecretKey)) {
+    console.error(
+      "❌ Error: destination credentials are required when --endpoint is set.\n" +
+        "  Provide --dest-access-key / --dest-secret-key, or set the\n" +
+        "  DEST_ACCESS_KEY_ID / DEST_SECRET_ACCESS_KEY environment variables.\n",
+    );
     printHelp();
     process.exit(1);
   }
@@ -207,6 +240,17 @@ OPTIONAL OPTIONS
                                   before copying. By default the destination is left
                                   untouched and files are only added/overwritten.
   --region      <aws-region>    AWS region  (default: eu-central-1)
+  --endpoint    <url>           Custom S3 endpoint URL for the DESTINATION only.
+                                  Use for local MinIO: --endpoint http://localhost:9000
+                                  The source always uses standard AWS S3.
+                                  Requires --dest-access-key and --dest-secret-key.
+                                  forcePathStyle is enabled automatically.
+  --dest-access-key <key>       Access key ID for the destination (MinIO) bucket.
+                                  Required when --endpoint is set (unless
+                                  DEST_ACCESS_KEY_ID env var is set).
+  --dest-secret-key <secret>    Secret access key for the destination (MinIO) bucket.
+                                  Required when --endpoint is set (unless
+                                  DEST_SECRET_ACCESS_KEY env var is set).
   --dry-run                     Print all operations without executing any of them
   --help, -h                    Show this help text
 
@@ -230,6 +274,21 @@ PROD → INT EXAMPLE (with password stored in $PGPASSWORD)
     export PGPASSWORD='p@ss#word'
     --db "postgresql://<user>@<prod-host>:5432/assets"
 
+LOCAL DEV EXAMPLE (copy from INT into local MinIO — data streams through this machine)
+  export DEST_ACCESS_KEY_ID=<STORAGE_ACCESS_KEY from development/.env>
+  export DEST_SECRET_ACCESS_KEY=<STORAGE_ACCESS_KEY_SECRET from development/.env>
+  node swissgeol-assets-s3-sync.mjs \\
+    --src-bucket  swissgeol-assets-int-swisstopo \\
+    --src-path  asset/asset_files/ \\
+    --dest-bucket asset-sg \\
+    --dest-path asset/asset_files/ \\
+    --endpoint http://localhost:9000 \\
+    --db "postgresql://<user>@<int-host>:5432/asset-swissgeol"
+
+  Source AWS credentials are taken from the standard credential chain (env vars,
+  ~/.aws/credentials, AWS SSO, etc.) — do NOT set AWS_ACCESS_KEY_ID/SECRET to
+  MinIO values, as that would break access to the source bucket.
+
 NOTE
   The PostgreSQL DB dump from PROD must be imported into INT manually
   BEFORE running this script. This script only handles S3 file synchronisation.
@@ -252,16 +311,14 @@ async function fetchFileNames(connectionString, workgroups, dbSsl, dbSslNoVerify
           `SELECT f.file_name
            FROM asset AS a
              INNER JOIN workgroup  AS w  ON w.id         = a.workgroup_id
-             INNER JOIN asset_file AS af ON af.asset_id  = a.asset_id
-             INNER JOIN file       AS f  ON f.id         = af.file_id
+             INNER JOIN file       AS f  ON f.asset_id         = a.asset_id
            WHERE w.name = ANY($1)`,
           [workgroups],
         )
       : await client.query(
           `SELECT f.file_name
            FROM asset AS a
-             INNER JOIN asset_file AS af ON af.asset_id  = a.asset_id
-             INNER JOIN file       AS f  ON f.id         = af.file_id`,
+             INNER JOIN file       AS f  ON f.asset_id         = a.asset_id`,
         );
     return rows.map((r) => r.file_name);
   } finally {
@@ -380,7 +437,7 @@ function prompt(question) {
 // Pre-flight S3 access check
 // ---------------------------------------------------------------------------
 
-async function checkS3Access(s3, srcBucket, srcPath, destBucket, destPath) {
+async function checkS3Access(srcS3, destS3, srcBucket, srcPath, destBucket, destPath) {
   console.log("\n[Step 2/5] Pre-flight S3 access check ...");
 
   const errors = [];
@@ -388,7 +445,7 @@ async function checkS3Access(s3, srcBucket, srcPath, destBucket, destPath) {
   // 1. Check source: list up to 1 key under srcPath to confirm read access + valid token.
   process.stdout.write("  Source bucket  (ListObjects) ... ");
   try {
-    await s3.send(new ListObjectsV2Command({ Bucket: srcBucket, Prefix: srcPath, MaxKeys: 1 }));
+    await srcS3.send(new ListObjectsV2Command({ Bucket: srcBucket, Prefix: srcPath, MaxKeys: 1 }));
     console.log("✓");
   } catch (err) {
     const detail = [err.Code ?? err.code ?? err.name, err.message].filter(Boolean).join(" — ");
@@ -400,7 +457,7 @@ async function checkS3Access(s3, srcBucket, srcPath, destBucket, destPath) {
   const sentinelKey = `${destPath}.s3sync-preflight-${Date.now()}`;
   process.stdout.write("  Destination bucket  (PutObject) ... ");
   try {
-    await s3.send(
+    await destS3.send(
       new PutObjectCommand({ Bucket: destBucket, Key: sentinelKey, Body: Buffer.alloc(0), ContentLength: 0 }),
     );
     console.log("✓");
@@ -412,7 +469,7 @@ async function checkS3Access(s3, srcBucket, srcPath, destBucket, destPath) {
 
   process.stdout.write("  Destination bucket  (DeleteObject) ... ");
   try {
-    await s3.send(new DeleteObjectCommand({ Bucket: destBucket, Key: sentinelKey }));
+    await destS3.send(new DeleteObjectCommand({ Bucket: destBucket, Key: sentinelKey }));
     console.log("✓");
   } catch (err) {
     const detail = [err.Code ?? err.code ?? err.name, err.message].filter(Boolean).join(" — ");
@@ -564,10 +621,71 @@ async function copyMultipart(s3, srcBucket, srcKey, destBucket, destKey, content
 }
 
 // ---------------------------------------------------------------------------
+// Cross-service streaming copy (AWS S3 → MinIO or any other endpoint)
+// Data flows through this machine: GET from source, PUT/UploadPart to destination.
+// ---------------------------------------------------------------------------
+
+async function copySingleObjectStream(srcS3, destS3, srcBucket, srcKey, destBucket, destKey) {
+  const { Body, ContentLength } = await srcS3.send(new GetObjectCommand({ Bucket: srcBucket, Key: srcKey }));
+  await destS3.send(new PutObjectCommand({ Bucket: destBucket, Key: destKey, Body, ContentLength }));
+}
+
+async function copyMultipartStream(srcS3, destS3, srcBucket, srcKey, destBucket, destKey, contentLength, onPartCopied) {
+  const { UploadId } = await destS3.send(new CreateMultipartUploadCommand({ Bucket: destBucket, Key: destKey }));
+
+  const parts = [];
+  try {
+    let byteOffset = 0;
+    let partNumber = 1;
+
+    while (byteOffset < contentLength) {
+      const end = Math.min(byteOffset + MULTIPART_PART_SIZE - 1, contentLength - 1);
+      const range = `bytes=${byteOffset}-${end}`;
+
+      // Download the chunk from the source
+      const { Body } = await srcS3.send(new GetObjectCommand({ Bucket: srcBucket, Key: srcKey, Range: range }));
+      const chunks = [];
+      for await (const chunk of Body) chunks.push(chunk);
+      const buffer = Buffer.concat(chunks);
+
+      // Upload the chunk to the destination
+      const { ETag } = await destS3.send(
+        new UploadPartCommand({
+          Bucket: destBucket,
+          Key: destKey,
+          UploadId,
+          PartNumber: partNumber,
+          Body: buffer,
+          ContentLength: buffer.length,
+        }),
+      );
+
+      parts.push({ PartNumber: partNumber, ETag });
+      const partBytes = end - byteOffset + 1;
+      byteOffset = end + 1;
+      partNumber++;
+      if (onPartCopied) onPartCopied(partBytes);
+    }
+
+    await destS3.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: destBucket,
+        Key: destKey,
+        UploadId,
+        MultipartUpload: { Parts: parts },
+      }),
+    );
+  } catch (err) {
+    await destS3.send(new AbortMultipartUploadCommand({ Bucket: destBucket, Key: destKey, UploadId }));
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Size scan
 // ---------------------------------------------------------------------------
 
-async function scanFileSizes(s3, fileNames, srcBucket, srcPath) {
+async function scanFileSizes(srcS3, fileNames, srcBucket, srcPath) {
   const ui = new TerminalUI();
   const t0 = Date.now();
   const trunc = (s, n) => (s.length > n ? s.slice(0, n - 1) + "…" : s);
@@ -592,7 +710,7 @@ async function scanFileSizes(s3, fileNames, srcBucket, srcPath) {
       while (idx < fileNames.length) {
         const fileName = fileNames[idx++];
         try {
-          const { ContentLength } = await s3.send(
+          const { ContentLength } = await srcS3.send(
             new HeadObjectCommand({ Bucket: srcBucket, Key: `${srcPath}${fileName}` }),
           );
           (ContentLength > COPY_OBJECT_MAX_BYTES ? multiFiles : singleFiles).push({
@@ -660,7 +778,8 @@ async function scanFileSizes(s3, fileNames, srcBucket, srcPath) {
 // Copy
 // ---------------------------------------------------------------------------
 
-async function copyFiles(s3, singleFiles, multiFiles, srcBucket, srcPath, destBucket, destPath, dryRun) {
+async function copyFiles(srcS3, destS3, singleFiles, multiFiles, srcBucket, srcPath, destBucket, destPath, dryRun) {
+  const crossService = srcS3 !== destS3;
   const ui = new TerminalUI();
   const trunc = (s, n) => (s.length > n ? s.slice(0, n - 1) + "…" : s);
   const allErrors = [];
@@ -717,7 +836,16 @@ async function copyFiles(s3, singleFiles, multiFiles, srcBucket, srcPath, destBu
           active.set(fileName, true);
           redraw();
           try {
-            await copySingleObject(s3, srcBucket, `${srcPath}${fileName}`, destBucket, `${destPath}${fileName}`);
+            await (crossService
+              ? copySingleObjectStream(
+                  srcS3,
+                  destS3,
+                  srcBucket,
+                  `${srcPath}${fileName}`,
+                  destBucket,
+                  `${destPath}${fileName}`,
+                )
+              : copySingleObject(destS3, srcBucket, `${srcPath}${fileName}`, destBucket, `${destPath}${fileName}`));
             const ms = Date.now() - t0;
             copied++;
             totalMs += ms;
@@ -793,19 +921,34 @@ async function copyFiles(s3, singleFiles, multiFiles, srcBucket, srcPath, destBu
       active.set(fileName, activeInfo);
       redraw();
       try {
-        await copyMultipart(
-          s3,
-          srcBucket,
-          `${srcPath}${fileName}`,
-          destBucket,
-          `${destPath}${fileName}`,
-          contentLength,
-          (partBytes) => {
-            bytesCopied += partBytes;
-            activeInfo.bytesDone += partBytes;
-            redraw();
-          },
-        );
+        await (crossService
+          ? copyMultipartStream(
+              srcS3,
+              destS3,
+              srcBucket,
+              `${srcPath}${fileName}`,
+              destBucket,
+              `${destPath}${fileName}`,
+              contentLength,
+              (partBytes) => {
+                bytesCopied += partBytes;
+                activeInfo.bytesDone += partBytes;
+                redraw();
+              },
+            )
+          : copyMultipart(
+              destS3,
+              srcBucket,
+              `${srcPath}${fileName}`,
+              destBucket,
+              `${destPath}${fileName}`,
+              contentLength,
+              (partBytes) => {
+                bytesCopied += partBytes;
+                activeInfo.bytesDone += partBytes;
+                redraw();
+              },
+            ));
         const ms = Date.now() - t0;
         copied++;
         totalMs += ms;
@@ -856,10 +999,23 @@ async function main() {
     `  Delete dest : ${args.deleteDestFiles ? "yes — destination will be wiped before copy" : "no (use --delete-dest-files to wipe first)"}`,
   );
   console.log(`  Region      : ${args.region}`);
+  if (args.endpoint) console.log(`  Endpoint    : ${args.endpoint}  (destination only, forcePathStyle enabled)`);
   if (args.dryRun) console.log("  Mode        : ⚠️ DRY-RUN — no changes will be made");
   console.log("");
 
-  const s3 = new S3Client({ region: args.region });
+  // Source always uses the standard AWS credential chain.
+  const srcS3 = new S3Client({ region: args.region });
+
+  // Destination uses a custom endpoint + explicit credentials when --endpoint is set (e.g. local MinIO),
+  // otherwise it also uses the standard AWS credential chain (same-service copy).
+  const destS3 = args.endpoint
+    ? new S3Client({
+        region: args.region,
+        endpoint: args.endpoint,
+        forcePathStyle: true,
+        credentials: { accessKeyId: args.destAccessKey, secretAccessKey: args.destSecretKey },
+      })
+    : srcS3;
 
   // Step 1: query DB for file list (before confirmation so the user sees the count)
   console.log("[Step 1/5] Querying the source database for asset files ...");
@@ -880,17 +1036,17 @@ async function main() {
   console.log("");
 
   // Step 2: pre-flight access check — verify token and permissions before doing anything destructive
-  await checkS3Access(s3, args.srcBucket, args.srcPath, args.destBucket, args.destPath);
+  await checkS3Access(srcS3, destS3, args.srcBucket, args.srcPath, args.destBucket, args.destPath);
 
   // Step 3: optionally delete all objects at destination path
   if (args.deleteDestFiles) {
-    await deleteAllInPath(s3, args.destBucket, args.destPath, args.dryRun);
+    await deleteAllInPath(destS3, args.destBucket, args.destPath, args.dryRun);
   } else {
     console.log("\n[Step 3/5] Skipping destination deletion (use --delete-dest-files to enable).");
   }
 
   // Step 4: scan all file sizes and group into single / multipart
-  const { singleFiles, multiFiles, missing } = await scanFileSizes(s3, fileNames, args.srcBucket, args.srcPath);
+  const { singleFiles, multiFiles, missing } = await scanFileSizes(srcS3, fileNames, args.srcBucket, args.srcPath);
 
   // Confirm before copying
 
@@ -909,9 +1065,10 @@ async function main() {
     return;
   }
 
-  // Step 4: copy files in two phases
+  // Step 5: copy files in two phases
   const { copied, errors } = await copyFiles(
-    s3,
+    srcS3,
+    destS3,
     singleFiles,
     multiFiles,
     args.srcBucket,


### PR DESCRIPTION
Avoids single files crashing the indexing process.
Improves logging so we know what is going on.
Removes clutter (Font-Loading warnings) from Logs
Avoids crashing the NodeJS process if elastic imports fail (like exceeded Memory)