### PR TITLE
Fix PDF-Viewer, which had issues because of unwanted version bump

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import {
   Asset,
   AssetFile,
@@ -26,6 +27,11 @@ import { FileS3Service, SaveFileS3Options } from '@/features/assets/files/file-s
 import { CreateFileData, FileIdentifier, FileRepo } from '@/features/assets/files/file.repo';
 import { PdfMetadataService } from '@/features/assets/files/pdf-metadata.service';
 import { mapAssetLanguagesToPrismaUpdate } from '@/features/assets/prisma-asset';
+
+// eval('require') bypasses webpack's static require analysis so the path is resolved at runtime by Node.js.
+const STANDARD_FONT_DATA_URL =
+  path.join(path.dirname((eval('require') as NodeRequire).resolve('pdfjs-dist/package.json')), 'standard_fonts') +
+  path.sep;
 
 @Injectable()
 export class FileService {
@@ -225,9 +231,9 @@ export class FileService {
     // leak as unhandled rejections that crash Node.js.
     const loadingTask = getDocument({
       url: presignedUrl,
-      useSystemFonts: true,
+      standardFontDataUrl: STANDARD_FONT_DATA_URL,
       disableAutoFetch: true,
-      disableStream: true,
+      disableStream: false,
     });
     let doc: PDFDocumentProxy | null = null;
     try {

--- a/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
@@ -1,7 +1,13 @@
+import * as path from 'node:path';
 import { PageDimension } from '@asset-sg/shared/v2';
 import { Injectable, Logger } from '@nestjs/common';
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api';
+
+// eval('require') bypasses webpack's static require analysis so the path is resolved at runtime by Node.js.
+const STANDARD_FONT_DATA_URL =
+  path.join(path.dirname((eval('require') as NodeRequire).resolve('pdfjs-dist/package.json')), 'standard_fonts') +
+  path.sep;
 
 @Injectable()
 export class PdfMetadataService {
@@ -23,7 +29,7 @@ export class PdfMetadataService {
 
       loadingTask = getDocument({
         url: fileUrl,
-        useSystemFonts: true,
+        standardFontDataUrl: STANDARD_FONT_DATA_URL,
         disableAutoFetch: true,
         disableStream: false,
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "jsonwebtoken": "^9.0.0",
         "jwk-to-pem": "^2.0.5",
         "ol": "^7.2.2",
-        "pdfjs-dist": "^5.4.296",
+        "pdfjs-dist": "5.4.530",
         "prisma": "^6.7.0",
         "proj4": "^2.11.0",
         "query-string": "^8.1.0",
@@ -39656,15 +39656,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "version": "5.4.530",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
+      "integrity": "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=22.13.0 || >=24"
+        "node": ">=20.16.0 || >=22.3.0"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
+        "@napi-rs/canvas": "^0.1.84"
       }
     },
     "node_modules/pend": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jsonwebtoken": "^9.0.0",
     "jwk-to-pem": "^2.0.5",
     "ol": "^7.2.2",
-    "pdfjs-dist": "^5.4.296",
+    "pdfjs-dist": "5.4.530",
     "prisma": "^6.7.0",
     "proj4": "^2.11.0",
     "query-string": "^8.1.0",


### PR DESCRIPTION
pdfjs-dist fixed at version "5.4.530" instead of using "^".
This fixes PDF-Viewer. re-applied standardFontDataUrl workaround. It was working as expected before