### PR TITLE
Cancel long running file indexing processes

### DIFF
--- a/apps/client-asset-sg/docker/nginx.conf
+++ b/apps/client-asset-sg/docker/nginx.conf
@@ -54,6 +54,6 @@ server {
         }
 
         expires $expires;
-        try_files $uri$args $uri$args/ /index.html;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -27,6 +27,7 @@ import { FileS3Service, SaveFileS3Options } from '@/features/assets/files/file-s
 import { CreateFileData, FileIdentifier, FileRepo } from '@/features/assets/files/file.repo';
 import { PdfMetadataService } from '@/features/assets/files/pdf-metadata.service';
 import { mapAssetLanguagesToPrismaUpdate } from '@/features/assets/prisma-asset';
+import { withTimeout } from '@/utils/timeout';
 
 // eval('require') bypasses webpack's static require analysis so the path is resolved at runtime by Node.js.
 const STANDARD_FONT_DATA_URL =
@@ -237,7 +238,11 @@ export class FileService {
     });
     let doc: PDFDocumentProxy | null = null;
     try {
-      doc = await loadingTask.promise;
+      // Use a timeout so that huge PDFs (e.g. 3 GB) can't stall the entire sync.
+      // When the timeout fires, the generator exits and the finally block calls
+      // loadingTask.destroy(), which cancels the network request and cleans up.
+      // Newer versions of pdf-js allow to do this with a singal provided in getDocument
+      doc = await withTimeout(loadingTask.promise, 120_000, 'PDF loading timed out');
 
       for (let i = 1; i <= doc.numPages; i++) {
         const page = await doc.getPage(i);

--- a/apps/server-asset-sg/src/utils/timeout.ts
+++ b/apps/server-asset-sg/src/utils/timeout.ts
@@ -1,0 +1,13 @@
+/**
+ * Races a promise against a timeout. Rejects with an error if the timeout
+ * elapses before the promise settles. The timer is always cleaned up.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(message ?? `Timed out after ${ms}ms`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer!));
+}

--- a/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
+++ b/libs/client-shared/src/lib/components/pdf-viewer/pdf-viewer.service.ts
@@ -8,14 +8,17 @@ import {
   PDFDocumentLoadingTask,
   PDFDocumentProxy,
   TextLayer,
+  version,
 } from 'pdfjs-dist';
 import { PDFPageProxy, TextContent } from 'pdfjs-dist/types/src/display/api';
 import { SessionStorageService } from '../../services/session-storage.service';
 import { selectIsAnonymousMode } from '../../state/app-shared-state.selectors';
 import { PdfRenderTask, PDF_VIEWER_DEBUG } from './pdf-viewer.models';
 
-// Worker source for PDF JS. Note that this must match the path that is defined in the builder configuration
-GlobalWorkerOptions.workerSrc = 'assets/pdfjs/pdf.worker.min.mjs';
+// Worker source for PDF JS. Note that this must match the path that is defined in the builder configuration.
+// The version query parameter busts the browser cache when the pdfjs-dist version changes, since the worker
+// filename itself has no content hash.
+GlobalWorkerOptions.workerSrc = `assets/pdfjs/pdf.worker.min.mjs?v=${version}`;
 
 @Injectable()
 export class PdfViewerService implements OnDestroy {


### PR DESCRIPTION
Circumvent that corrupt or large PDF files can stall the pdfjs-dist extraction.

We race the pdfjs-dist promise against a timer which rejects the promise if it takes longer than 120s

To prevent version mismatches between bundled pdfjs and cached pdfjs-web-worker we reference the web-worker file by adding the correct version of it as query-parameter (v). -> Needs adjustiment of nginx config, which resolves files with a query-string incorrectly (concatenates path with query string), which worked so far, since none of the static files contained a queryString. Now we can use the query-string just as a cache-buster. Might become handy for future updates of pdf-js to circumvent stale web-workers