### PR TITLE
fix: suppress pdfjs-dist font warnings to prevent log explosion

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -255,6 +255,7 @@ export class FileService {
       standardFontDataUrl: STANDARD_FONT_DATA_URL,
       disableAutoFetch: true,
       disableStream: false,
+      verbosity: 0,
     });
     let doc: PDFDocumentProxy | null = null;
     try {

--- a/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
@@ -32,6 +32,7 @@ export class PdfMetadataService {
         standardFontDataUrl: STANDARD_FONT_DATA_URL,
         disableAutoFetch: true,
         disableStream: false,
+        verbosity: 0,
       });
       // Load the PDF document without fetching all pages
       doc = await loadingTask.promise;


### PR DESCRIPTION
PDFs with custom/embedded fonts cause pdfjs-dist to emit thousands of 'Font X is not available' warnings per second, flooding stdout and eventually crashing the application. Set verbosity to ERRORS-only on both getDocument() call sites to suppress these warnings.