### PR TITLE
fix: isolate integration tests from development database

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres_test?schema=public

--- a/apps/server-asset-sg/jest.config.ts
+++ b/apps/server-asset-sg/jest.config.ts
@@ -1,6 +1,7 @@
 export default {
   displayName: 'server-asset-sg',
   preset: '../../jest.preset.js',
+  globalSetup: './jest.global-setup.ts',
   setupFilesAfterEnv: ['./jest.setup.ts'],
   globals: {},
   testEnvironment: 'node',

--- a/apps/server-asset-sg/jest.global-setup.ts
+++ b/apps/server-asset-sg/jest.global-setup.ts
@@ -1,0 +1,29 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import * as dotenv from 'dotenv';
+
+export default async function globalSetup() {
+  dotenv.config({ path: path.resolve(process.cwd(), '.env.test'), override: true });
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl || !databaseUrl.includes('_test')) {
+    throw new Error(
+      'Refusing to run tests: DATABASE_URL does not point to a test database. ' +
+        'Ensure .env.test exists at the project root and contains a DATABASE_URL with a test database (e.g. postgres_test).',
+    );
+  }
+
+  try {
+    execSync('npx prisma migrate deploy --schema libs/persistence/prisma/schema.prisma', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: 'inherit',
+    });
+  } catch {
+    console.error(
+      '\n❌ Failed to apply migrations to the test database.\n' +
+        'If the database does not exist yet, create it with:\n\n' +
+        '  cd development && docker compose exec db psql -U postgres -c "CREATE DATABASE postgres_test;"\n',
+    );
+    process.exit(1);
+  }
+}

--- a/apps/server-asset-sg/jest.global-setup.ts
+++ b/apps/server-asset-sg/jest.global-setup.ts
@@ -1,12 +1,12 @@
-import { execSync } from 'child_process';
-import path from 'path';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
 import * as dotenv from 'dotenv';
 
 export default async function globalSetup() {
   dotenv.config({ path: path.resolve(process.cwd(), '.env.test'), override: true });
 
   const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl || !databaseUrl.includes('_test')) {
+  if (!databaseUrl?.includes('_test')) {
     throw new Error(
       'Refusing to run tests: DATABASE_URL does not point to a test database. ' +
         'Ensure .env.test exists at the project root and contains a DATABASE_URL with a test database (e.g. postgres_test).',

--- a/apps/server-asset-sg/jest.global-setup.ts
+++ b/apps/server-asset-sg/jest.global-setup.ts
@@ -15,7 +15,11 @@ export default async function globalSetup() {
 
   try {
     execSync('npx prisma migrate deploy --schema libs/persistence/prisma/schema.prisma', {
-      env: { ...process.env, DATABASE_URL: databaseUrl },
+      env: {
+        ...process.env,
+        DATABASE_URL: databaseUrl,
+        PATH: [path.dirname(process.execPath), '/usr/local/bin', '/usr/bin', '/bin'].join(path.delimiter),
+      },
       stdio: 'inherit',
     });
   } catch {

--- a/apps/server-asset-sg/jest.setup.ts
+++ b/apps/server-asset-sg/jest.setup.ts
@@ -3,4 +3,4 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({ path: '.env' });
 dotenv.config({ path: '.env.local' });
-dotenv.config({ path: '.env.test' });
+dotenv.config({ path: '.env.test', override: true });

--- a/development/init/db/00_create_test_db.sql
+++ b/development/init/db/00_create_test_db.sql
@@ -1,0 +1,7 @@
+CREATE DATABASE postgres_test;
+
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'assets') THEN
+    GRANT CONNECT ON DATABASE postgres_test TO "assets";
+  END IF;
+END $$;

--- a/test/setup-db.ts
+++ b/test/setup-db.ts
@@ -6,6 +6,14 @@ import { languageItems } from './data/language-items';
 import { manCatLabelItems } from './data/man-cat-label-item';
 
 const clearDB = async (prisma: PrismaClient, dbName: string): Promise<void> => {
+  const dbUrl = process.env.DATABASE_URL || '';
+  if (!dbUrl.includes('_test')) {
+    throw new Error(
+      'Refusing to clear database: DATABASE_URL does not point to a test database. ' +
+        'Ensure .env.test exists at the project root and contains a DATABASE_URL with a test database (e.g. postgres_test).',
+    );
+  }
+
   const tables = await prisma.$queryRawUnsafe(`
       SELECT table_name
       FROM information_schema.tables


### PR DESCRIPTION
 Tests in server-asset-sg use TRUNCATE on all tables, which wipes the
 development database when triggered (e.g. by AI coding agents running
 tests to verify changes).

 - Add dedicated postgres_test database for test isolation
 - Add .env.test with test DATABASE_URL
 - Add jest globalSetup to auto-apply migrations to test DB
 - Load .env.test with override in jest.setup.ts
 - Add safety guard in test/setup-db.ts refusing to clear non-test DBs