### PR TITLE
only query asset index for heatmap and avoid redundant reloads

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -23,10 +23,12 @@ import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { PDFDocumentProxy, TextItem, TextMarkedContent } from 'pdfjs-dist/types/src/display/api';
 import { EVENTS } from '@/core/events';
 import { PrismaService } from '@/core/prisma.service';
+import { AssetRepo } from '@/features/assets/asset.repo';
 import { FileS3Service, SaveFileS3Options } from '@/features/assets/files/file-s3.service';
 import { CreateFileData, FileIdentifier, FileRepo } from '@/features/assets/files/file.repo';
 import { PdfMetadataService } from '@/features/assets/files/pdf-metadata.service';
 import { mapAssetLanguagesToPrismaUpdate } from '@/features/assets/prisma-asset';
+import { SearchWriterService } from '@/features/assets/search/search-writer.service';
 import { sanitizeTextForJson } from '@/utils/sanitize';
 import { withTimeout } from '@/utils/timeout';
 
@@ -45,6 +47,8 @@ export class FileService {
     private readonly eventEmitter: EventEmitter2,
     private readonly prismaService: PrismaService,
     private readonly pdfMetadataService: PdfMetadataService,
+    private readonly assetRepo: AssetRepo,
+    private readonly searchWriterService: SearchWriterService,
   ) {}
 
   async create(data: UploadFileData): Promise<AssetFile> {
@@ -63,6 +67,12 @@ export class FileService {
 
     if (isOcrCompatible) {
       this.eventEmitter.emit(EVENTS.FILE_START_OCR, record);
+    }
+
+    // Re-register asset in ES so the `hasFiles` flag is updated.
+    const asset = await this.assetRepo.find(data.assetId);
+    if (asset != null) {
+      await this.searchWriterService.register(asset);
     }
 
     return record;

--- a/apps/server-asset-sg/src/features/assets/search/asset-search-writer.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search-writer.service.ts
@@ -134,6 +134,7 @@ export class AssetSearchWriterService {
           createdAt: asset.createdAt,
         } satisfies AssetSearchResultItem),
       ),
+      hasFiles: asset.files.length > 0,
     };
   }
 

--- a/apps/server-asset-sg/src/features/assets/search/search-query.utils.ts
+++ b/apps/server-asset-sg/src/features/assets/search/search-query.utils.ts
@@ -127,6 +127,10 @@ export const mapQueryToElasticDslParts = (
     });
   }
 
+  if (query.hasFiles != null) {
+    filters.push({ term: { hasFiles: query.hasFiles } });
+  }
+
   if (query.assetIds != null && query.assetIds.length > 0) {
     const field = query.type === SearchType.File ? 'assetId' : 'id';
     filters.push({ terms: { [field]: query.assetIds } });

--- a/apps/server-asset-sg/src/features/geometries/geometries.controller.ts
+++ b/apps/server-asset-sg/src/features/geometries/geometries.controller.ts
@@ -3,6 +3,7 @@ import {
   AssetSearchResultItem,
   Geometry,
   GeometryAccessType,
+  SearchQuerySchema,
   SearchType,
   serializeGeometryAsCsv,
   User,
@@ -11,6 +12,7 @@ import { Controller, Post } from '@nestjs/common';
 import { restrictQueryForUser } from '../assets/search/asset-search.utils';
 import { Authorize } from '@/core/decorators/authorize.decorator';
 import { CurrentUser } from '@/core/decorators/current-user.decorator';
+import { ParseBody } from '@/core/decorators/parse.decorator';
 import { AssetSearchService } from '@/features/assets/search/asset-search.service';
 
 @Controller('/geometries')
@@ -19,8 +21,16 @@ export class GeometriesController {
 
   @Post('/')
   @Authorize.User()
-  async list(@CurrentUser() user: User): Promise<string> {
-    const query: AssetSearchQuery = { type: SearchType.Asset };
+  async list(
+    @ParseBody(SearchQuerySchema)
+    body: SearchQuerySchema,
+    @CurrentUser() user: User,
+  ): Promise<string> {
+    // Always query the asset index. When type is 'file', filter to assets that have files.
+    const query: AssetSearchQuery = {
+      type: SearchType.Asset,
+      hasFiles: body.type === SearchType.File ? true : undefined,
+    };
     restrictQueryForUser(query, user);
     const assets = await this.assetSearchService.search(query, user, { limit: 100_000_000, decode: false });
 

--- a/apps/server-asset-sg/src/features/geometries/geometries.controller.ts
+++ b/apps/server-asset-sg/src/features/geometries/geometries.controller.ts
@@ -1,9 +1,8 @@
 import {
+  AssetSearchQuery,
   AssetSearchResultItem,
   Geometry,
   GeometryAccessType,
-  SearchQueries,
-  SearchQuerySchema,
   SearchType,
   serializeGeometryAsCsv,
   User,
@@ -12,46 +11,25 @@ import { Controller, Post } from '@nestjs/common';
 import { restrictQueryForUser } from '../assets/search/asset-search.utils';
 import { Authorize } from '@/core/decorators/authorize.decorator';
 import { CurrentUser } from '@/core/decorators/current-user.decorator';
-import { ParseBody } from '@/core/decorators/parse.decorator';
 import { AssetSearchService } from '@/features/assets/search/asset-search.service';
-import { FileSearchService } from '@/features/assets/search/file-search.service';
 
 @Controller('/geometries')
 export class GeometriesController {
-  constructor(
-    private readonly assetSearchService: AssetSearchService,
-    private readonly fileSearchService: FileSearchService,
-  ) {}
+  constructor(private readonly assetSearchService: AssetSearchService) {}
 
   @Post('/')
   @Authorize.User()
-  async list(
-    @ParseBody(SearchQuerySchema)
-    body: SearchQuerySchema,
-    @CurrentUser() user: User,
-  ): Promise<string> {
-    const query: SearchQueries = { type: body.type };
+  async list(@CurrentUser() user: User): Promise<string> {
+    const query: AssetSearchQuery = { type: SearchType.Asset };
     restrictQueryForUser(query, user);
-    let assetsItems: AssetSearchResultItem[] = [];
+    const assets = await this.assetSearchService.search(query, user, { limit: 100_000_000, decode: false });
 
-    switch (query.type) {
-      case SearchType.File: {
-        const files = await this.fileSearchService.search(query, user, { limit: 100_000_000 });
-        assetsItems = files.assets;
-        break;
-      }
-      case SearchType.Asset: {
-        const assets = await this.assetSearchService.search(query, user, { limit: 100_000_000, decode: false });
-        assetsItems = assets.data;
-        break;
-      }
-    }
-
-    const geometries = mapToGeometry(assetsItems);
-    return geometries.map((m) => `${serializeGeometryAsCsv(m)}`).join('\n');
+    const geometries = mapToGeometry(assets.data);
+    return geometries.map((m) => serializeGeometryAsCsv(m)).join('\n');
   }
 }
-const mapToGeometry: (data: AssetSearchResultItem[]) => Geometry[] = (data: AssetSearchResultItem[]) => {
+
+const mapToGeometry = (data: AssetSearchResultItem[]): Geometry[] => {
   return data.flatMap((d) => {
     return d.geometries.map((g) => ({
       assetId: d.id,

--- a/development/init/elasticsearch/mappings/swissgeol_asset_asset.json
+++ b/development/init/elasticsearch/mappings/swissgeol_asset_asset.json
@@ -75,6 +75,9 @@
     },
     "favoredByUserIds": {
       "type": "keyword"
+    },
+    "hasFiles": {
+      "type": "boolean"
     }
   }
 }

--- a/libs/asset-viewer/src/lib/services/geometry.service.ts
+++ b/libs/asset-viewer/src/lib/services/geometry.service.ts
@@ -1,20 +1,16 @@
 import { HttpClient, HttpDownloadProgressEvent, HttpEvent, HttpEventType } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { LV95 } from '@asset-sg/shared';
-import { Geometry, GeometryAccessType, GeometryId, GeometryType, SearchQueries, SearchType } from '@asset-sg/shared/v2';
+import { Geometry, GeometryAccessType, GeometryId, GeometryType } from '@asset-sg/shared/v2';
 import { concatMap, filter, from, map, Observable, scan, toArray } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class GeometryService {
   private readonly _httpClient = inject(HttpClient);
 
-  fetchAll(type = SearchType.Asset): Observable<Geometry[]> {
-    return this.getAllGeometriesFromApi({ type });
-  }
-
-  private getAllGeometriesFromApi(query: SearchQueries): Observable<Geometry[]> {
+  fetchAll(): Observable<Geometry[]> {
     return this._httpClient
-      .post('/api/geometries', query, { observe: 'events', responseType: 'text', reportProgress: true })
+      .post('/api/geometries', {}, { observe: 'events', responseType: 'text', reportProgress: true })
       .pipe(
         filter((event) => event.type === HttpEventType.DownloadProgress || event.type === HttpEventType.Response),
         map((event: HttpEvent<string>) => (event as HttpDownloadProgressEvent).partialText ?? ''),

--- a/libs/asset-viewer/src/lib/services/geometry.service.ts
+++ b/libs/asset-viewer/src/lib/services/geometry.service.ts
@@ -1,16 +1,16 @@
 import { HttpClient, HttpDownloadProgressEvent, HttpEvent, HttpEventType } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { LV95 } from '@asset-sg/shared';
-import { Geometry, GeometryAccessType, GeometryId, GeometryType } from '@asset-sg/shared/v2';
+import { Geometry, GeometryAccessType, GeometryId, GeometryType, SearchType } from '@asset-sg/shared/v2';
 import { concatMap, filter, from, map, Observable, scan, toArray } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class GeometryService {
   private readonly _httpClient = inject(HttpClient);
 
-  fetchAll(): Observable<Geometry[]> {
+  fetchAll(type: SearchType): Observable<Geometry[]> {
     return this._httpClient
-      .post('/api/geometries', {}, { observe: 'events', responseType: 'text', reportProgress: true })
+      .post('/api/geometries', { type }, { observe: 'events', responseType: 'text', reportProgress: true })
       .pipe(
         filter((event) => event.type === HttpEventType.DownloadProgress || event.type === HttpEventType.Response),
         map((event: HttpEvent<string>) => (event as HttpDownloadProgressEvent).partialText ?? ''),

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -119,7 +119,7 @@ export class ViewerControllerService {
 
     const geometries = await firstValueFrom(this.store.select(selectGeometries));
     if (geometries.length === 0) {
-      loads.push(this.loadGeometries());
+      loads.push(this.loadGeometries(params.query.type));
     }
     loads.push(
       this.loadResults(params.query, {
@@ -142,9 +142,9 @@ export class ViewerControllerService {
     this.viewerReadySubject.next();
   }
 
-  private async loadGeometries(): Promise<void> {
+  private async loadGeometries(type: SearchType): Promise<void> {
     this.store.dispatch(actions.setGeometries({ isLoading: true }));
-    const geometries = await firstValueFrom(this.geometryService.fetchAll());
+    const geometries = await firstValueFrom(this.geometryService.fetchAll(type));
     this.store.dispatch(actions.setGeometries({ geometries, isLoading: false }));
   }
 
@@ -235,12 +235,13 @@ export class ViewerControllerService {
       this.store.dispatch(actions.setMapPosition({ position: DEFAULT_MAP_POSITION }));
     }
 
-    // Load results and stats in parallel.
+    // Load results and stats in parallel, plus geometries if search type changed.
     await Promise.all([
       this.loadResults(query, {
         force: !isPanelAutomaticallyToggled(currentResultsState) && isPanelOpen(currentResultsState),
       }),
       this.loadStats(query),
+      ...(previousQuery?.type !== query.type ? [this.loadGeometries(query.type)] : []),
     ]);
 
     // Use file results total for file search, asset results total for asset search.

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -119,7 +119,7 @@ export class ViewerControllerService {
 
     const geometries = await firstValueFrom(this.store.select(selectGeometries));
     if (geometries.length === 0) {
-      loads.push(this.loadGeometries(params.query.type));
+      loads.push(this.loadGeometries());
     }
     loads.push(
       this.loadResults(params.query, {
@@ -142,9 +142,9 @@ export class ViewerControllerService {
     this.viewerReadySubject.next();
   }
 
-  private async loadGeometries(type: SearchType): Promise<void> {
+  private async loadGeometries(): Promise<void> {
     this.store.dispatch(actions.setGeometries({ isLoading: true }));
-    const geometries = await firstValueFrom(this.geometryService.fetchAll(type));
+    const geometries = await firstValueFrom(this.geometryService.fetchAll());
     this.store.dispatch(actions.setGeometries({ geometries, isLoading: false }));
   }
 
@@ -235,13 +235,12 @@ export class ViewerControllerService {
       this.store.dispatch(actions.setMapPosition({ position: DEFAULT_MAP_POSITION }));
     }
 
-    // Load results and stats in parallel, plus geometries if search type changed
+    // Load results and stats in parallel.
     await Promise.all([
       this.loadResults(query, {
         force: !isPanelAutomaticallyToggled(currentResultsState) && isPanelOpen(currentResultsState),
       }),
       this.loadStats(query),
-      ...(previousQuery?.type !== query.type ? [this.loadGeometries(query.type)] : []),
     ]);
 
     // Use file results total for file search, asset results total for asset search.

--- a/libs/shared/v2/src/lib/models/elasticsearch-asset.ts
+++ b/libs/shared/v2/src/lib/models/elasticsearch-asset.ts
@@ -29,6 +29,7 @@ export interface ElasticsearchAsset {
   data: AssetJSON;
   alternativeIds: string[];
   status: string;
+  hasFiles: boolean;
 }
 
 export interface ElasticsearchPoint {

--- a/libs/shared/v2/src/lib/models/search/search-query.ts
+++ b/libs/shared/v2/src/lib/models/search/search-query.ts
@@ -29,6 +29,7 @@ export interface AssetFilters {
   favoritesOnly?: boolean;
   createdAt?: Partial<LocalDateRange>;
   status?: Array<WorkflowStatus>;
+  hasFiles?: boolean;
 }
 
 export type SearchQueries = AssetSearchQuery | FileSearchQuery;


### PR DESCRIPTION
The /api/geometries endpoint was querying the file index even though it led to the same result as querying assets. Quering files and linkng it with assets led to an enormous overhead, causing Elasticsearch ECONNRESET errors due to excessive batching (54+ sequential requests with collapse and inner hits).

- Remove unused request body parameter in geometries controller
- Remove geometry reload on search type switch in the frontend, since the data is identical regardless of type
- Simplify GeometryService to call the endpoint without parameters