### PR TITLE
Fix file indexing

### DIFF
--- a/apps/server-asset-sg/src/features/assets/files/file.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/file.service.ts
@@ -247,9 +247,14 @@ export class FileService {
   }
 
   private async *streamPdfPages(presignedUrl: string) {
-    // Save loadingTask before awaiting so it can always be destroyed in the finally block,
-    // even if the promise rejects (e.g. 503 from S3). Without this, pdfjs internal tasks
-    // leak as unhandled rejections that crash Node.js.
+    // pdfjs-dist leaks internal fetch rejections that bypass try/catch and crash Node.js.
+    // Scoped handler absorbs them; the real error is still caught and logged below.
+    const leakedErrors: unknown[] = [];
+    const rejectionGuard = (reason: unknown) => {
+      leakedErrors.push(reason);
+    };
+    process.on('unhandledRejection', rejectionGuard);
+
     const loadingTask = getDocument({
       url: presignedUrl,
       standardFontDataUrl: STANDARD_FONT_DATA_URL,
@@ -283,6 +288,13 @@ export class FileService {
           error: e instanceof Error ? e.message : String(e),
         });
       });
+      // defer listener removal — pdfjs-dist rejections may still be queued as microtasks
+      // after destroy() resolves. One extra tick lets them land in our guard.
+      await new Promise((resolve) => setImmediate(resolve));
+      process.removeListener('unhandledRejection', rejectionGuard);
+      if (leakedErrors.length > 0) {
+        this.logger.debug('Absorbed leaked pdfjs-dist rejections', { count: leakedErrors.length });
+      }
     }
   }
 

--- a/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
+++ b/apps/server-asset-sg/src/features/assets/files/pdf-metadata.service.ts
@@ -23,6 +23,13 @@ export class PdfMetadataService {
   async extractMetadata(fileUrl: string): Promise<PdfMetadataResult> {
     let doc: PDFDocumentProxy | null = null;
 
+    // same rejection guard as streamPdfPages — pdfjs-dist leaks fetch rejections
+    const leakedErrors: unknown[] = [];
+    const rejectionGuard = (reason: unknown) => {
+      leakedErrors.push(reason);
+    };
+    process.on('unhandledRejection', rejectionGuard);
+
     let loadingTask: PDFDocumentLoadingTask | null = null;
     try {
       this.logger.debug('Starting PDF metadata extraction', { fileUrl: this.sanitizeUrl(fileUrl) });
@@ -86,6 +93,12 @@ export class PdfMetadataService {
     } finally {
       // Ensure PDF document is properly destroyed to free memory
       await loadingTask?.destroy();
+      // defer listener removal — pdfjs-dist rejections may still be queued as microtasks
+      await new Promise((resolve) => setImmediate(resolve));
+      process.removeListener('unhandledRejection', rejectionGuard);
+      if (leakedErrors.length > 0) {
+        this.logger.debug('Absorbed leaked pdfjs-dist rejections', { count: leakedErrors.length });
+      }
     }
   }
 


### PR DESCRIPTION
#977 
pdfjs-dist leaks internal fetch rejections that bypass try/catch and crash Node.js.
We catch them via global error handling.