### PR TITLE
Feature/assets 843 improve routing

### DIFF
--- a/apps/client-asset-sg/src/app/app.module.ts
+++ b/apps/client-asset-sg/src/app/app.module.ts
@@ -70,8 +70,11 @@ const routes: Routes = [
         loadChildren: loadAssetViewer,
       },
       {
+        // assets rout is never used within the app, could be removed.
+        // To support old bookmarks we redirect it to the root-url (/:lang)
         path: 'assets',
-        loadChildren: loadAssetViewer,
+        redirectTo: '',
+        pathMatch: 'full',
       },
       {
         path: 'favorites',

--- a/apps/client-asset-sg/src/app/components/app-bar/app-bar.component.ts
+++ b/apps/client-asset-sg/src/app/components/app-bar/app-bar.component.ts
@@ -2,7 +2,7 @@ import { ENTER } from '@angular/cdk/keycodes';
 import { HttpClient } from '@angular/common/http';
 import { Component, ElementRef, inject, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { appSharedStateActions, AuthService, fromAppShared } from '@asset-sg/client-shared';
+import { appSharedStateActions, AuthService, fromAppShared, LanguageService } from '@asset-sg/client-shared';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import * as O from 'fp-ts/Option';
@@ -31,6 +31,7 @@ export class AppBarComponent implements OnInit {
   private readonly store = inject(Store<AppState>);
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
+  private readonly languageService = inject(LanguageService);
 
   public readonly isAnonymous$ = this.store.select(fromAppShared.selectIsAnonymousMode);
 
@@ -67,6 +68,6 @@ export class AppBarComponent implements OnInit {
   async logout(): Promise<void> {
     this.authService.logOut();
     this.store.dispatch(appSharedStateActions.logout());
-    await this.router.navigate(['/']);
+    await this.router.navigate([`/${this.languageService.language}`]);
   }
 }

--- a/apps/client-asset-sg/src/app/components/menu-bar/menu-bar.component.ts
+++ b/apps/client-asset-sg/src/app/components/menu-bar/menu-bar.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, HostBinding, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { can$, fromAppShared, ROUTER_SEGMENTS } from '@asset-sg/client-shared';
+import { can$, fromAppShared, LanguageService, ROUTER_SEGMENTS } from '@asset-sg/client-shared';
 import { AssetEditPolicy } from '@asset-sg/shared/v2';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
@@ -35,6 +35,7 @@ export class MenuBarComponent {
 
   private readonly router = inject(Router);
   private readonly store = inject(Store<AppState>);
+  private readonly languageService = inject(LanguageService);
 
   private readonly routerSegments$ = inject(ROUTER_SEGMENTS);
 
@@ -78,8 +79,9 @@ export class MenuBarComponent {
   }
 
   goToViewer({ favoritesOnly }: { favoritesOnly: boolean }): void {
-    const basePath = '/';
-    const favoritesPath = '/favorites';
+    const lang = this.languageService.language;
+    const basePath = `/${lang}`;
+    const favoritesPath = `/${lang}/favorites`;
 
     const [sourcePath, targetPath] = favoritesOnly ? [basePath, favoritesPath] : [favoritesPath, basePath];
 

--- a/apps/client-asset-sg/src/app/state/app.effects.ts
+++ b/apps/client-asset-sg/src/app/state/app.effects.ts
@@ -1,6 +1,12 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { appSharedStateActions, AuthService, fromAppShared, LanguageService } from '@asset-sg/client-shared';
+import {
+  appSharedStateActions,
+  AuthService,
+  fromAppShared,
+  LanguageService,
+  replaceLanguageInUrl,
+} from '@asset-sg/client-shared';
 import { isNotNull } from '@asset-sg/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
@@ -30,8 +36,7 @@ export class AppSharedStateEffects {
         if (currentLang === user.lang) {
           return;
         }
-        const currentUrl = this.router.url; // e.g. "/de/admin/users?foo=bar#section"
-        const newUrl = `/${user.lang}${currentUrl.substring(currentLang.length + 1)}`;
+        const newUrl = replaceLanguageInUrl(this.router.url, currentLang, user.lang);
         this.router.navigateByUrl(newUrl, { replaceUrl: true });
       });
 

--- a/apps/client-asset-sg/src/app/state/app.effects.ts
+++ b/apps/client-asset-sg/src/app/state/app.effects.ts
@@ -1,11 +1,11 @@
 import { inject, Injectable } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { appSharedStateActions, AuthService, fromAppShared, LanguageService } from '@asset-sg/client-shared';
 import { isNotNull } from '@asset-sg/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { combineLatest, filter, map, switchMap, take } from 'rxjs';
+import { filter, map, switchMap, take } from 'rxjs';
 import { AppSharedStateService } from './app-shared-state.service';
 import { AppState } from './app-state';
 
@@ -20,21 +20,19 @@ export class AppSharedStateEffects {
   languageService = inject(LanguageService);
 
   constructor() {
-    combineLatest([
-      this.store.select(fromAppShared.selectUser).pipe(filter(isNotNull)),
-      this.router.events.pipe(filter((e) => e instanceof NavigationEnd)),
-    ])
-      .pipe(take(1), untilDestroyed(this))
-      .subscribe(([user]) => {
-        if (this.languageService.language === user.lang) {
+    // Once the user profile is loaded, switch to the user's preferred language (if different)
+    // The URL is updated to reflect the new language via replaceUrl so the back button isn't affected.
+    this.store
+      .select(fromAppShared.selectUser)
+      .pipe(filter(isNotNull), take(1), untilDestroyed(this))
+      .subscribe((user) => {
+        const currentLang = this.languageService.language;
+        if (currentLang === user.lang) {
           return;
         }
-        const urlTree = this.router.parseUrl(this.router.url);
-        const segments = urlTree.root.children['primary']?.segments;
-        if (segments && segments.length > 0) {
-          segments[0].path = user.lang;
-        }
-        this.router.navigateByUrl(urlTree, { replaceUrl: true }).then();
+        const currentUrl = this.router.url; // e.g. "/de/admin/users?foo=bar#section"
+        const newUrl = `/${user.lang}${currentUrl.substring(currentLang.length + 1)}`;
+        this.router.navigateByUrl(newUrl, { replaceUrl: true });
       });
 
     this.actions$.pipe(ofType(appSharedStateActions.logout), untilDestroyed(this)).subscribe(() => {

--- a/apps/client-asset-sg/src/app/state/app.effects.ts
+++ b/apps/client-asset-sg/src/app/state/app.effects.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { appSharedStateActions, AuthService, fromAppShared } from '@asset-sg/client-shared';
+import { appSharedStateActions, AuthService, fromAppShared, LanguageService } from '@asset-sg/client-shared';
 import { isNotNull } from '@asset-sg/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
@@ -17,6 +17,7 @@ export class AppSharedStateEffects {
   appSharedStateService = inject(AppSharedStateService);
   authService = inject(AuthService);
   router = inject(Router);
+  languageService = inject(LanguageService);
 
   constructor() {
     combineLatest([
@@ -25,10 +26,15 @@ export class AppSharedStateEffects {
     ])
       .pipe(take(1), untilDestroyed(this))
       .subscribe(([user]) => {
-        // Change the URL to the current user's language.
-        const url = this.router.url;
-        const newUrl = `/${user.lang}${url.slice(3)}`;
-        this.router.navigateByUrl(newUrl).then();
+        if (this.languageService.language === user.lang) {
+          return;
+        }
+        const urlTree = this.router.parseUrl(this.router.url);
+        const segments = urlTree.root.children['primary']?.segments;
+        if (segments && segments.length > 0) {
+          segments[0].path = user.lang;
+        }
+        this.router.navigateByUrl(urlTree, { replaceUrl: true }).then();
       });
 
     this.actions$.pipe(ofType(appSharedStateActions.logout), untilDestroyed(this)).subscribe(() => {

--- a/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
+++ b/libs/asset-editor/src/lib/components/asset-editor-page/asset-editor-page.component.ts
@@ -175,7 +175,7 @@ export class AssetEditorPageComponent implements OnInit, OnDestroy {
   }
 
   public navigateToStart() {
-    this.router.navigate(['/']).then();
+    this.router.navigate([`/${this.languageService.language}`]).then();
   }
 
   public initializeForm() {

--- a/libs/asset-editor/src/lib/state/asset-editor.effects.ts
+++ b/libs/asset-editor/src/lib/state/asset-editor.effects.ts
@@ -1,7 +1,14 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { AssetSearchService } from '@asset-sg/asset-viewer';
-import { Alert, AlertType, appSharedStateActions, fromAppShared, showAlert } from '@asset-sg/client-shared';
+import {
+  Alert,
+  AlertType,
+  appSharedStateActions,
+  fromAppShared,
+  LanguageService,
+  showAlert,
+} from '@asset-sg/client-shared';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
@@ -18,6 +25,7 @@ export class AssetEditorEffects {
   private readonly actions$ = inject(Actions);
   private readonly store = inject(Store);
   private readonly router = inject(Router);
+  private readonly languageService = inject(LanguageService);
   private readonly assetEditorService = inject(AssetEditorService);
   private readonly assetSearchService = inject(AssetSearchService);
   private readonly workflowApiService = inject(WorkflowApiService);
@@ -75,7 +83,7 @@ export class AssetEditorEffects {
     this.actions$.pipe(
       ofType(actions.handleSuccessfulDeletion),
       switchMap(async ({ assetId }) => {
-        await this.router.navigate(['/']);
+        await this.router.navigate([`/${this.languageService.language}`]);
         return assetId;
       }),
       map((assetId) => appSharedStateActions.removeAsset({ assetId })),

--- a/libs/asset-viewer/src/lib/services/viewer-params.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-params.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { Params, Router } from '@angular/router';
-import { AppSharedState } from '@asset-sg/client-shared';
+import { AppSharedState, LanguageService } from '@asset-sg/client-shared';
 import { isNotNull } from '@asset-sg/core';
 import { LV95 } from '@asset-sg/shared';
 import { AssetId, isEmptySearchQuery, LocalDate, Polygon, SearchQueries, SearchType } from '@asset-sg/shared/v2';
@@ -19,6 +19,7 @@ import {
 export class ViewerParamsService {
   private readonly router = inject(Router);
   private readonly store = inject(Store<AppStateWithAssetSearch>);
+  private readonly languageService = inject(LanguageService);
 
   async readParamsFromStore(): Promise<ViewerParams> {
     const [searchState, sharedState] = await firstValueFrom(
@@ -102,18 +103,18 @@ export class ViewerParamsService {
     updatePlainParam(params, UI_PARAM_MAPPING.map.y, ui.map.y, { defaultValue: DEFAULT_MAP_POSITION.y });
     updatePlainParam(params, UI_PARAM_MAPPING.map.z, ui.map.z, { defaultValue: DEFAULT_MAP_POSITION.z });
 
-    const url = document.location.pathname.split('/', 3);
     const route = query.favoritesOnly ? ['favorites'] : [];
 
-    await this.router.navigate([url[1], ...route], {
+    await this.router.navigate([this.languageService.language, ...route], {
       queryParams: params,
       replaceUrl: options.shouldReplaceUrl,
     });
   }
 
   private parseFavoritesOnlyFromUrl(): boolean | undefined {
-    const url = document.location.pathname.split('/', 3);
-    return url.length === 3 && url[2] === 'favorites' ? true : undefined;
+    const path = this.router.url.split('?')[0].split('#')[0];
+    const segments = path.split('/');
+    return segments.length >= 3 && segments[2] === 'favorites' ? true : undefined;
   }
 }
 

--- a/libs/client-shared/src/lib/guards/prefix-path-with-language.guard.spec.ts
+++ b/libs/client-shared/src/lib/guards/prefix-path-with-language.guard.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlSegment } from '@angular/router';
+import { Language } from '@swissgeol/ui-core';
+
+import { LanguageService } from '../services';
+import { prefixPathWithLanguageGuard } from './prefix-path-with-language.guard';
+
+describe('prefixPathWithLanguageGuard', () => {
+  let languageService: { language: Language; setLanguage: jest.Mock };
+  let router: { currentNavigation: jest.Mock; createUrlTree: jest.Mock };
+
+  beforeEach(() => {
+    languageService = {
+      language: Language.German,
+      setLanguage: jest.fn(),
+    };
+    router = {
+      currentNavigation: jest.fn().mockReturnValue({ extractedUrl: { queryParams: {} } }),
+      createUrlTree: jest.fn().mockReturnValue('/mock-tree'),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: LanguageService, useValue: languageService },
+        { provide: Router, useValue: router },
+      ],
+    });
+  });
+
+  const runGuard = (segments: UrlSegment[]) =>
+    TestBed.runInInjectionContext(() => prefixPathWithLanguageGuard({} as any, segments));
+
+  it('returns true and sets language when first segment is a valid language', () => {
+    const segments = [new UrlSegment('fr', {}), new UrlSegment('admin', {})];
+    const result = runGuard(segments);
+
+    expect(result).toBe(true);
+    expect(languageService.setLanguage).toHaveBeenCalledWith(Language.French);
+  });
+
+  it('returns true without calling setLanguage when language already matches', () => {
+    const segments = [new UrlSegment('de', {}), new UrlSegment('admin', {})];
+    const result = runGuard(segments);
+
+    expect(result).toBe(true);
+    // setLanguage is called — the guard always calls it, the service itself short-circuits
+    expect(languageService.setLanguage).toHaveBeenCalledWith(Language.German);
+  });
+
+  it('redirects with language prefix when first segment is not a language', () => {
+    const segments = [new UrlSegment('admin', {}), new UrlSegment('users', {})];
+    const result = runGuard(segments);
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['de', 'admin', 'users'], { queryParams: {} });
+    expect(result).toBeDefined();
+    expect(result).not.toBe(true);
+  });
+
+  it('redirects with language prefix when segments are empty', () => {
+    const result = runGuard([]);
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['de'], { queryParams: {} });
+    expect(result).toBeDefined();
+    expect(result).not.toBe(true);
+  });
+
+  it('preserves query params from the current navigation when redirecting', () => {
+    router.currentNavigation.mockReturnValue({
+      extractedUrl: { queryParams: { assetId: '123', foo: 'bar' } },
+    });
+
+    const segments = [new UrlSegment('admin', {})];
+    runGuard(segments);
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['de', 'admin'], {
+      queryParams: { assetId: '123', foo: 'bar' },
+    });
+  });
+
+  it('handles missing currentNavigation gracefully', () => {
+    router.currentNavigation.mockReturnValue(null);
+
+    const segments = [new UrlSegment('admin', {})];
+    runGuard(segments);
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['de', 'admin'], { queryParams: {} });
+  });
+
+  it('recognizes all supported languages', () => {
+    for (const lang of Object.values(Language)) {
+      const segments = [new UrlSegment(lang, {})];
+      const result = runGuard(segments);
+
+      expect(result).toBe(true);
+      expect(languageService.setLanguage).toHaveBeenCalledWith(lang);
+    }
+  });
+
+  it('does not treat an invalid language code as valid', () => {
+    const segments = [new UrlSegment('xx', {})];
+    const result = runGuard(segments);
+
+    expect(result).not.toBe(true);
+    expect(router.createUrlTree).toHaveBeenCalled();
+  });
+});

--- a/libs/client-shared/src/lib/utils/index.ts
+++ b/libs/client-shared/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ export * from './consent-cookie';
 export * from './custom-property';
 export * from './map';
 export * from './map-styles';
+export * from './replace-language-in-url';
 export * from './wgs';
 export * from './router-segments';
 export * from './wkt-to-geojson';

--- a/libs/client-shared/src/lib/utils/replace-language-in-url.spec.ts
+++ b/libs/client-shared/src/lib/utils/replace-language-in-url.spec.ts
@@ -1,0 +1,27 @@
+import { replaceLanguageInUrl } from './replace-language-in-url';
+
+describe('replaceLanguageInUrl', () => {
+  it('replaces a 2-char language prefix in a simple path', () => {
+    expect(replaceLanguageInUrl('/de/admin', 'de', 'fr')).toBe('/fr/admin');
+  });
+
+  it('replaces the language when the URL is just the language', () => {
+    expect(replaceLanguageInUrl('/de', 'de', 'fr')).toBe('/fr');
+  });
+
+  it('preserves query params', () => {
+    expect(replaceLanguageInUrl('/de/admin?assetId=123&foo=bar', 'de', 'it')).toBe('/it/admin?assetId=123&foo=bar');
+  });
+
+  it('preserves fragment', () => {
+    expect(replaceLanguageInUrl('/de/admin#section', 'de', 'fr')).toBe('/fr/admin#section');
+  });
+
+  it('handles deep paths', () => {
+    expect(replaceLanguageInUrl('/de/admin/users/42/edit', 'de', 'en')).toBe('/en/admin/users/42/edit');
+  });
+
+  it('handles root path with trailing slash', () => {
+    expect(replaceLanguageInUrl('/de/', 'de', 'fr')).toBe('/fr/');
+  });
+});

--- a/libs/client-shared/src/lib/utils/replace-language-in-url.ts
+++ b/libs/client-shared/src/lib/utils/replace-language-in-url.ts
@@ -1,0 +1,8 @@
+/**
+ * Replaces the language prefix in a URL string.
+ *
+ * @example replaceLanguageInUrl('/de/admin?x=1#top', 'de', 'fr') → '/fr/admin?x=1#top'
+ */
+export function replaceLanguageInUrl(currentUrl: string, currentLang: string, newLang: string): string {
+  return `/${newLang}${currentUrl.substring(currentLang.length + 1)}`;
+}


### PR DESCRIPTION
**Einheitliche Navigation mit Sprache**

In `app.effects.ts` wurde die Sprachüberschreibung nach Login zusätzlich optimiert: sie greift nur noch, wenn die Sprache tatsächlich abweicht.
Routing wurde vereinheitlicht und über all der sprach parameter mit rein genommen um redirects zu vermeiden.

Die Route `assets` lud dasselbe Modul wie `/`, wurde aber nirgends verlinkt. Jetzt ein `redirectTo: ''/`  (Bookmark-Kompatibilität)