### PR TITLE
fix: add explicit ES mapping for data field and use sourceFields for retrieval

### DIFF
--- a/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
+++ b/apps/server-asset-sg/src/features/assets/search/asset-search.service.ts
@@ -40,12 +40,12 @@ export class AssetSearchService {
     const { results, total } = await this.searchService.search(
       elasticQuery,
       { limit, offset },
-      { storedFields: ['id', 'data'] },
+      { sourceFields: ['id', 'data'] },
     );
 
     const data: AssetSearchResultItem[] = [];
     for (const hit of results.values()) {
-      const encodedAsset = JSON.parse(hit.fields?.['data']?.[0] as string);
+      const encodedAsset = JSON.parse(hit.source?.['data'] as string);
       data.push(
         shouldDecode
           ? plainToInstance(AssetSearchResultItemSchema, encodedAsset, { excludeExtraneousValues: true })

--- a/apps/server-asset-sg/src/features/assets/search/search-query.utils.ts
+++ b/apps/server-asset-sg/src/features/assets/search/search-query.utils.ts
@@ -187,7 +187,7 @@ export const getDateTimeString = (): string => {
   return (
     '' +
     now.getUTCFullYear() +
-    padZero(now.getUTCMonth()) +
+    padZero(now.getUTCMonth() + 1) +
     padZero(now.getUTCDate()) +
     padZero(now.getUTCHours()) +
     padZero(now.getUTCMinutes()) +

--- a/development/init/elasticsearch/mappings/swissgeol_asset_asset.json
+++ b/development/init/elasticsearch/mappings/swissgeol_asset_asset.json
@@ -78,6 +78,10 @@
     },
     "hasFiles": {
       "type": "boolean"
+    },
+    "data": {
+      "type": "text",
+      "index": false
     }
   }
 }

--- a/development/init/elasticsearch/mappings/swissgeol_asset_file.json
+++ b/development/init/elasticsearch/mappings/swissgeol_asset_file.json
@@ -97,6 +97,10 @@
     "content": {
       "type": "text",
       "term_vector": "with_positions_offsets"
+    },
+    "data": {
+      "type": "text",
+      "index": false
     }
   }
 }


### PR DESCRIPTION
- Add 'data' field with 'index: false' to asset and file ES mappings to prevent wasteful text analysis of JSON payloads on reindex
- Switch AssetSearchService from storedFields (fields API) to sourceFields (_source filtering), consistent with FileSearchService
- Fix off-by-one in getDateTimeString: getUTCMonth() returns 0-11