### PR TITLE
feat(export): add restriction type column to CSV export

### DIFF
--- a/apps/server-asset-sg/src/features/assets/export/asset-export.i18n.ts
+++ b/apps/server-asset-sg/src/features/assets/export/asset-export.i18n.ts
@@ -23,7 +23,8 @@ type Localized = Record<ExportLanguage, string>;
 export const CSV_COLUMN_KEYS = [
   'title',
   'status',
-  'restriction',
+  'restrictionType',
+  'restrictionDate',
   'topic',
   'kind',
   'language',
@@ -49,7 +50,8 @@ export type CsvColumnKey = (typeof CSV_COLUMN_KEYS)[number];
 export const CSV_PUBLIC_COLUMNS: Record<CsvColumnKey, boolean> = {
   title: true,
   status: true,
-  restriction: true,
+  restrictionType: true,
+  restrictionDate: true,
   topic: true,
   kind: true,
   language: true,
@@ -73,7 +75,13 @@ export const CSV_PUBLIC_COLUMNS: Record<CsvColumnKey, boolean> = {
 export const CSV_COLUMN_HEADERS: Record<CsvColumnKey, Localized> = {
   title: { de: 'Öffentlicher Titel', fr: 'Titre public', it: 'Titolo pubblico', en: 'Public title' },
   status: { de: 'Status', fr: 'Statut', it: 'Stato', en: 'Status' },
-  restriction: { de: 'Beschränkung', fr: 'Restriction', it: 'Restrizione', en: 'Restriction' },
+  restrictionType: { de: 'Beschränkung', fr: 'Restriction', it: 'Restrizione', en: 'Restriction' },
+  restrictionDate: {
+    de: 'Beschränkungsdatum',
+    fr: 'Date de restriction',
+    it: 'Data di restrizione',
+    en: 'Restriction date',
+  },
   topic: { de: 'Thema', fr: 'Thème', it: 'Tema', en: 'Topic' },
   kind: { de: 'Typ', fr: 'Type', it: 'Tipo', en: 'Kind' },
   language: { de: 'Sprache', fr: 'Langue', it: 'Lingua', en: 'Language' },
@@ -136,3 +144,9 @@ export const BOOLEAN_LABELS: { true: Localized; false: Localized } = {
   true: { de: 'Ja', fr: 'Oui', it: 'Sì', en: 'Yes' },
   false: { de: 'Nein', fr: 'Non', it: 'No', en: 'No' },
 };
+
+export const RESTRICTION_TYPE_LABELS = {
+  free: { de: 'frei', fr: 'libre', it: 'libero', en: 'free' },
+  locked: { de: 'gesperrt', fr: 'bloqué', it: 'bloccato', en: 'locked' },
+  lockedUntil: { de: 'gesperrt bis', fr: "bloqué jusqu'au", it: 'bloccato fino al', en: 'locked until' },
+} as const;

--- a/apps/server-asset-sg/src/features/assets/export/asset-export.service.ts
+++ b/apps/server-asset-sg/src/features/assets/export/asset-export.service.ts
@@ -24,6 +24,7 @@ import {
   CSV_PUBLIC_COLUMNS,
   CsvColumnKey,
   ExportLanguage,
+  RESTRICTION_TYPE_LABELS,
   WORKFLOW_STATUS_LABELS,
 } from '@/features/assets/export/asset-export.i18n';
 import { ContactRepo } from '@/features/contacts/contact.repo';
@@ -99,7 +100,15 @@ export class AssetExportService {
         return asset.title;
       case 'status':
         return WORKFLOW_STATUS_LABELS[asset.workflowStatus]?.[language] ?? asset.workflowStatus;
-      case 'restriction':
+      case 'restrictionType': {
+        if (asset.isPublic) {
+          return RESTRICTION_TYPE_LABELS.free[language];
+        }
+        return asset.restrictionDate != null
+          ? RESTRICTION_TYPE_LABELS.lockedUntil[language]
+          : RESTRICTION_TYPE_LABELS.locked[language];
+      }
+      case 'restrictionDate':
         return asset.restrictionDate?.toString() ?? '';
       case 'topic':
         return joinCodes(asset.topicCodes, references.topics);


### PR DESCRIPTION
Split the 'restriction' column into two separate columns: 
restriction type and restriction date