### PR TITLE
Hotfix/assets-1022: not all assets published

### DIFF
--- a/apps/sync-asset-sg/src/core/config.ts
+++ b/apps/sync-asset-sg/src/core/config.ts
@@ -1,5 +1,12 @@
 export type Mode = 'view' | 'extern';
 
+/**
+ * Number of full file rows (including their large JSON columns) fetched, transformed and inserted per iteration while
+ * exporting files. A single conservative value bounds the file-export memory peak to at most this many file rows at a
+ * time, independent of the asset batch size. Each chunk is inserted and released before the next chunk is fetched.
+ */
+export const FILE_CHUNK_SIZE = 100;
+
 export interface SyncConfig {
   mode: Mode;
   syncAssignee: string | undefined;

--- a/apps/sync-asset-sg/src/core/export-to-view.service.spec.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.spec.ts
@@ -58,7 +58,7 @@ function file(id: number, assetId: number, type: 'Normal' | 'Legal', overrides: 
     id,
     assetId,
     type,
-    size: 1n,
+    size: BigInt(1),
     fulltextContent: null,
     pageRangeClassifications: null,
     pageDimensions: null,

--- a/apps/sync-asset-sg/src/core/export-to-view.service.spec.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.spec.ts
@@ -1,0 +1,334 @@
+import { SyncConfig } from './config';
+import { ExportToViewService } from './export-to-view.service';
+
+// Suppress log output during tests
+jest.mock('./log', () => ({
+  log: jest.fn(),
+}));
+
+// Keep this in sync with FILE_CHUNK_SIZE in export-to-view.service.ts.
+const FILE_CHUNK_SIZE = 10;
+
+const config: SyncConfig = {
+  mode: 'view',
+  syncAssignee: 'test@test.com',
+  source: { connectionString: 'source', allowedWorkgroupIds: [1] },
+  destination: { connectionString: 'destination', allowedWorkgroupIds: [1] },
+};
+
+type PublishData = {
+  authors: boolean;
+  initiators: boolean;
+  suppliers: boolean;
+  general: boolean;
+  geometries: boolean;
+  legacy: boolean;
+  normalFiles: boolean;
+  legalFiles: boolean;
+  references: boolean;
+};
+
+function publishData(overrides: Partial<PublishData> = {}): PublishData {
+  return {
+    authors: false,
+    initiators: false,
+    suppliers: false,
+    general: false,
+    geometries: false,
+    legacy: false,
+    normalFiles: false,
+    legalFiles: false,
+    references: false,
+    ...overrides,
+  };
+}
+
+interface FileRow {
+  id: number;
+  assetId: number;
+  type: 'Normal' | 'Legal';
+  size: bigint;
+  fulltextContent: unknown;
+  pageRangeClassifications: unknown;
+  pageDimensions: unknown;
+}
+
+function file(id: number, assetId: number, type: 'Normal' | 'Legal', overrides: Partial<FileRow> = {}): FileRow {
+  return {
+    id,
+    assetId,
+    type,
+    size: 1n,
+    fulltextContent: null,
+    pageRangeClassifications: null,
+    pageDimensions: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal in-memory emulation of `prisma.file.findMany`. It only emulates what `exportFiles` relies on:
+ *   - `where.OR` of `{ assetId: { in }, type }` branches (the publishable-type filter),
+ *   - `where.id.in` (the chunked full-row fetch),
+ *   - `select.id` (id-only projection),
+ *   - `orderBy.id === 'asc'` (deterministic ordering).
+ * Everything else is asserted directly against the recorded mock calls, not recreated here.
+ */
+function makeFileFindMany(db: FileRow[]) {
+  return jest.fn(async (args: any) => {
+    let rows = db;
+    const where = args?.where ?? {};
+
+    if (Array.isArray(where.OR)) {
+      rows = rows.filter((row) =>
+        where.OR.some(
+          (branch: any) =>
+            (branch.assetId?.in ? branch.assetId.in.includes(row.assetId) : true) &&
+            (branch.type ? branch.type === row.type : true),
+        ),
+      );
+    }
+
+    if (where.id?.in) {
+      rows = rows.filter((row) => where.id.in.includes(row.id));
+    }
+
+    if (args?.orderBy?.id === 'asc') {
+      // Copy before sorting so the original fixture array is never mutated.
+      rows = [...rows].sort((a, b) => a.id - b.id);
+    }
+
+    if (args?.select?.id) {
+      return rows.map((row) => ({ id: row.id }));
+    }
+    return rows;
+  });
+}
+
+function createService(db: FileRow[], configs: Map<number, { publishData: PublishData }>) {
+  const fileFindMany = makeFileFindMany(db);
+  const fileCreateMany = jest
+    .fn()
+    .mockImplementation(async ({ data }: { data: unknown[] }) => ({ count: data.length }));
+
+  const sourcePrisma = {
+    file: { findMany: fileFindMany },
+  } as any;
+  const destinationPrisma = {
+    file: { createMany: fileCreateMany },
+  } as any;
+
+  const service = new ExportToViewService(sourcePrisma, destinationPrisma, config);
+
+  // Populate the existing (readonly) map instance rather than replacing it, to mirror production behaviour.
+  const serviceConfigs = (service as any).publicAssetConfigs as Map<number, { publishData: PublishData }>;
+  for (const [id, value] of configs) {
+    serviceConfigs.set(id, value);
+  }
+
+  return { service, sourcePrisma, destinationPrisma, fileFindMany, fileCreateMany };
+}
+
+function exportFiles(service: ExportToViewService, assetIds: number[], batchNumber = 1): Promise<void> {
+  return (service as any).exportFiles(assetIds, batchNumber);
+}
+
+/** The id-only "which files to export" query is always the first findMany call. */
+function idQueryCall(fileFindMany: jest.Mock) {
+  return fileFindMany.mock.calls[0][0];
+}
+
+/** The subsequent full-row fetches select complete rows via `where.id.in`. */
+function fullRowQueryCalls(fileFindMany: jest.Mock) {
+  return fileFindMany.mock.calls.map((call) => call[0]).filter((args) => args?.where?.id?.in !== undefined);
+}
+
+describe('ExportToViewService.exportFiles', () => {
+  it('exports only publishable file types per asset (filtered in the id query)', async () => {
+    const db: FileRow[] = [
+      file(10, 1, 'Normal'),
+      file(11, 1, 'Legal'),
+      file(20, 2, 'Normal'),
+      file(21, 2, 'Legal'),
+      file(30, 3, 'Normal'),
+      file(31, 3, 'Legal'),
+    ];
+    const configs = new Map<number, { publishData: PublishData }>([
+      [1, { publishData: publishData({ normalFiles: true }) }], // only Normal
+      [2, { publishData: publishData({ legalFiles: true }) }], // only Legal
+      [3, { publishData: publishData({ normalFiles: true, legalFiles: true }) }], // both
+      // asset 4 has no config at all
+    ]);
+
+    const { service, fileFindMany, fileCreateMany } = createService(db, configs);
+    await exportFiles(service, [1, 2, 3, 4]);
+
+    // The generated id query must filter both types in the database, select ids only, and order deterministically.
+    expect(idQueryCall(fileFindMany)).toEqual({
+      where: {
+        OR: [
+          { assetId: { in: [1, 3] }, type: 'Normal' },
+          { assetId: { in: [2, 3] }, type: 'Legal' },
+        ],
+      },
+      select: { id: true },
+      orderBy: { id: 'asc' },
+    });
+
+    // ...and the resulting inserted rows match that filter (asset1 Normal, asset2 Legal, asset3 both).
+    const inserted = fileCreateMany.mock.calls.flatMap((call) => call[0].data as Array<{ id: number }>);
+    expect(inserted.map((f) => f.id).sort((a, b) => a - b)).toEqual([10, 21, 30, 31]);
+    for (const call of fileCreateMany.mock.calls) {
+      expect(call[0].skipDuplicates).toBe(true);
+    }
+  });
+
+  it('runs an id-only first query that never fetches the heavy JSON columns', async () => {
+    const db: FileRow[] = [file(10, 1, 'Normal')];
+    const configs = new Map<number, { publishData: PublishData }>([
+      [1, { publishData: publishData({ normalFiles: true }) }],
+    ]);
+
+    const { service, fileFindMany } = createService(db, configs);
+    await exportFiles(service, [1]);
+
+    expect(fileFindMany.mock.calls[0][0].select).toEqual({ id: true });
+  });
+
+  it('does not query or insert files when no asset publishes files', async () => {
+    const db: FileRow[] = [file(10, 1, 'Normal')];
+    const configs = new Map<number, { publishData: PublishData }>([[1, { publishData: publishData() }]]);
+
+    const { service, sourcePrisma, fileCreateMany } = createService(db, configs);
+    await exportFiles(service, [1]);
+
+    expect(sourcePrisma.file.findMany).not.toHaveBeenCalled();
+    expect(fileCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('runs the id query but skips full-row fetch and insert when publication is enabled but no file matches', async () => {
+    // Publication is enabled, but there is no Normal file to export.
+    const db: FileRow[] = [file(11, 1, 'Legal')];
+    const configs = new Map<number, { publishData: PublishData }>([
+      [1, { publishData: publishData({ normalFiles: true }) }],
+    ]);
+
+    const { service, fileFindMany, fileCreateMany } = createService(db, configs);
+    await exportFiles(service, [1]);
+
+    // The id query runs...
+    expect(fileFindMany).toHaveBeenCalledTimes(1);
+    expect(idQueryCall(fileFindMany).select).toEqual({ id: true });
+    // ...but there is no full-row fetch and no insert.
+    expect(fullRowQueryCalls(fileFindMany)).toHaveLength(0);
+    expect(fileCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('passes through the large JSON columns of exported files unchanged (no clone/serialize)', async () => {
+    const fulltext = { pages: [{ text: 'hello world' }] };
+    const ranges = [{ from: 1, to: 2 }];
+    const dims = [{ width: 100, height: 200 }];
+    const db: FileRow[] = [
+      file(10, 1, 'Normal', { fulltextContent: fulltext, pageRangeClassifications: ranges, pageDimensions: dims }),
+    ];
+    const configs = new Map<number, { publishData: PublishData }>([
+      [1, { publishData: publishData({ normalFiles: true }) }],
+    ]);
+
+    const { service, fileCreateMany } = createService(db, configs);
+    await exportFiles(service, [1]);
+
+    const inserted = fileCreateMany.mock.calls.flatMap((call) => call[0].data as any[]);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({ id: 10 });
+    // Reference equality proves the JSON values are forwarded as-is, not cloned or re-serialized.
+    expect(inserted[0].fulltextContent).toBe(fulltext);
+    expect(inserted[0].pageRangeClassifications).toBe(ranges);
+    expect(inserted[0].pageDimensions).toBe(dims);
+  });
+
+  it('inserts exactly one bounded chunk when there are exactly FILE_CHUNK_SIZE files', async () => {
+    const db: FileRow[] = Array.from({ length: FILE_CHUNK_SIZE }, (_, i) => file(100 + i, 1, 'Normal'));
+    const configs = new Map<number, { publishData: PublishData }>([
+      [1, { publishData: publishData({ normalFiles: true }) }],
+    ]);
+
+    const { service, fileCreateMany } = createService(db, configs);
+    await exportFiles(service, [1]);
+
+    expect(fileCreateMany).toHaveBeenCalledTimes(1);
+    expect(fileCreateMany.mock.calls[0][0].data).toHaveLength(FILE_CHUNK_SIZE);
+    expect(fileCreateMany.mock.calls[0][0].skipDuplicates).toBe(true);
+  });
+
+  it('fetches and inserts in fixed-size chunks without accumulating rows across chunks', async () => {
+    const total = FILE_CHUNK_SIZE * 2 + 3; // 23 -> chunks of 10, 10, 3
+    const db: FileRow[] = Array.from({ length: total }, (_, i) => file(100 + i, 1, 'Normal'));
+    const configs = new Map<number, { publishData: PublishData }>([
+      [1, { publishData: publishData({ normalFiles: true }) }],
+    ]);
+
+    const { service, fileFindMany, fileCreateMany } = createService(db, configs);
+    await exportFiles(service, [1]);
+
+    const fullRowCalls = fullRowQueryCalls(fileFindMany);
+    const insertCalls = fileCreateMany.mock.calls.map((c) => c[0]);
+
+    // Exactly three full-row fetches and three inserts (10, 10, 3).
+    expect(fullRowCalls).toHaveLength(3);
+    expect(insertCalls).toHaveLength(3);
+
+    const fetchIdChunks = fullRowCalls.map((args) => args.where.id.in as number[]);
+    const insertIdChunks = insertCalls.map((args) => (args.data as Array<{ id: number }>).map((f) => f.id));
+
+    fullRowCalls.forEach((args, index) => {
+      // Full-row queries must fetch complete rows (no id-only projection) and stay ordered.
+      expect(args.select).toBeUndefined();
+      expect(args.orderBy).toEqual({ id: 'asc' });
+      // Must not carry the original Normal/Legal OR filter.
+      expect(args.where.OR).toBeUndefined();
+      // Each insert is bounded and uses skipDuplicates.
+      expect(insertIdChunks[index].length).toBeLessThanOrEqual(FILE_CHUNK_SIZE);
+      expect(insertCalls[index].skipDuplicates).toBe(true);
+      // Each insert corresponds exactly to its matching fetch chunk (no cross-chunk reuse).
+      expect(insertIdChunks[index]).toEqual(fetchIdChunks[index]);
+    });
+
+    // Chunk sizes are exactly 10, 10, 3.
+    expect(fetchIdChunks.map((c) => c.length)).toEqual([FILE_CHUNK_SIZE, FILE_CHUNK_SIZE, 3]);
+
+    // No id appears in more than one fetch chunk, and every file is inserted exactly once.
+    const allFetchIds = fetchIdChunks.flat();
+    expect(new Set(allFetchIds).size).toBe(allFetchIds.length);
+    const insertedIds = insertIdChunks.flat();
+    expect(insertedIds.sort((a, b) => a - b)).toEqual(db.map((f) => f.id));
+  });
+});
+
+describe('ExportToViewService.exportToView', () => {
+  it('verifies the outer batch flow calls exportFiles after exportAssets', async () => {
+    // Drive the outer batch loop with a single public asset while stubbing every heavy collaborator.
+    const destinationPrisma = { $executeRaw: jest.fn().mockResolvedValue(0) } as any;
+    const service = new ExportToViewService({} as any, destinationPrisma, config);
+
+    const order: string[] = [];
+
+    jest
+      .spyOn(service as any, 'findPublicAssetIds')
+      .mockResolvedValue([{ assetId: 1, workgroupId: 1, publishData: publishData() }]);
+    jest.spyOn(service as any, 'exportItems').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'export').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'exportSiblings').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'exportAssets').mockImplementation(async () => {
+      order.push('assets');
+    });
+    jest.spyOn(service as any, 'exportFiles').mockImplementation(async () => {
+      order.push('files');
+    });
+
+    await service.exportToView();
+
+    expect(order).toEqual(['assets', 'files']);
+    expect((service as any).exportFiles).toHaveBeenCalledWith([1], 1);
+  });
+});

--- a/apps/sync-asset-sg/src/core/export-to-view.service.spec.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.spec.ts
@@ -1,13 +1,10 @@
-import { SyncConfig } from './config';
+import { FILE_CHUNK_SIZE, SyncConfig } from './config';
 import { ExportToViewService } from './export-to-view.service';
 
 // Suppress log output during tests
 jest.mock('./log', () => ({
   log: jest.fn(),
 }));
-
-// Keep this in sync with FILE_CHUNK_SIZE in export-to-view.service.ts.
-const FILE_CHUNK_SIZE = 10;
 
 const config: SyncConfig = {
   mode: 'view',

--- a/apps/sync-asset-sg/src/core/export-to-view.service.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.ts
@@ -1,6 +1,6 @@
 import { getHeapStatistics } from 'v8';
 import { Prisma, PrismaClient } from '@prisma/client';
-import { SyncConfig } from './config';
+import { FILE_CHUNK_SIZE, SyncConfig } from './config';
 import { log } from './log';
 
 /**
@@ -51,13 +51,6 @@ interface AssetInfo {
 
 const BATCH_SIZE = 100;
 const BATCH_SIZE_GEOMETRIES = 10_000;
-
-/**
- * Number of full file rows (including their large JSON columns) fetched, transformed and inserted per iteration while
- * exporting files. A single conservative value bounds the file-export memory peak to at most this many file rows at a
- * time, independent of the asset batch size. Each chunk is inserted and released before the next chunk is fetched.
- */
-const FILE_CHUNK_SIZE = 10;
 
 export class ExportToViewService {
   private readonly allowedWorkgroupIds: number[];

--- a/apps/sync-asset-sg/src/core/export-to-view.service.ts
+++ b/apps/sync-asset-sg/src/core/export-to-view.service.ts
@@ -1,3 +1,4 @@
+import { getHeapStatistics } from 'v8';
 import { Prisma, PrismaClient } from '@prisma/client';
 import { SyncConfig } from './config';
 import { log } from './log';
@@ -5,6 +6,10 @@ import { log } from './log';
 /**
  * Contains all attributes that should be published, _except_ the geometries which need to be merged manually due to
  * missing PostGIS support in Prisma.
+ *
+ * Note: files are intentionally *not* selected here. They are exported separately in a bounded, chunked fashion by
+ * {@link ExportToViewService.exportFiles} to avoid holding the large JSON columns (`fulltextContent`,
+ * `pageRangeClassifications`, `pageDimensions`) of every file of a whole asset batch in memory at once.
  */
 type PublishedAssetSelection = Prisma.AssetGetPayload<{
   select: {
@@ -14,7 +19,6 @@ type PublishedAssetSelection = Prisma.AssetGetPayload<{
     createDate: true;
     receiptDate: true;
     assetContacts: true;
-    files: true;
     isNatRel: true;
     assetKindItemCode: true;
     assetFormatItemCode: true;
@@ -48,6 +52,13 @@ interface AssetInfo {
 const BATCH_SIZE = 100;
 const BATCH_SIZE_GEOMETRIES = 10_000;
 
+/**
+ * Number of full file rows (including their large JSON columns) fetched, transformed and inserted per iteration while
+ * exporting files. A single conservative value bounds the file-export memory peak to at most this many file rows at a
+ * time, independent of the asset batch size. Each chunk is inserted and released before the next chunk is fetched.
+ */
+const FILE_CHUNK_SIZE = 10;
+
 export class ExportToViewService {
   private readonly allowedWorkgroupIds: number[];
   private readonly publicAssetConfigs: Map<number, Omit<AssetInfo, 'assetId'>> = new Map();
@@ -62,6 +73,8 @@ export class ExportToViewService {
   }
 
   public async exportToView() {
+    this.publicAssetConfigs.clear();
+
     const publicAssets = await this.findPublicAssetIds();
     publicAssets.forEach(({ assetId, ...rest }) => this.publicAssetConfigs.set(assetId, rest));
 
@@ -77,17 +90,20 @@ export class ExportToViewService {
 
     // batch the list of public asset ids
     for (const [index, batch] of batches.entries()) {
-      log(`Export batch #${index + 1}`);
+      const batchNumber = index + 1;
+      log(`Export batch #${batchNumber}`);
       const time = Date.now();
       const assetIds = batch.map((item) => item.assetId);
       await this.exportAssets(assetIds);
+      await this.exportFiles(assetIds, batchNumber);
       await this.export('assetLanguage', 'assetId', assetIds, true);
 
       await this.export('manCatLabelRef', 'assetId', assetIds, true);
       await this.export('typeNatRel', 'assetId', assetIds, true);
 
       const timeTaken = Date.now() - time;
-      log(`Exported batch #${index + 1} of ${assetIds.length} assets in ${timeTaken} ms.`, 'batch');
+      log(`Exported batch #${batchNumber} of ${assetIds.length} assets in ${timeTaken} ms.`, 'batch');
+      this.logMemoryUsage(`after batch #${batchNumber}`, { batch: batchNumber, assets: assetIds.length });
     }
 
     // only export siblings after all assets have been exported so no foreign key constraint is violated
@@ -120,6 +136,10 @@ export class ExportToViewService {
 
   /**
    * Export assets with the given ids.
+   *
+   * Note: files are intentionally *not* exported here. They are exported by {@link ExportToViewService.exportFiles}
+   * from the outer batch loop, so that the local `assets`, `filteredAssets` and contact arrays of this method become
+   * unreachable (and collectible) before any heavy file rows are fetched.
    */
   private async exportAssets(assetIds: number[]) {
     const assets: PublishedAssetSelection[] = await this.sourcePrisma.asset.findMany({
@@ -135,7 +155,6 @@ export class ExportToViewService {
         createDate: true,
         receiptDate: true,
         assetContacts: true,
-        files: true,
         isNatRel: true,
         assetKindItemCode: true,
         assetFormatItemCode: true,
@@ -159,15 +178,6 @@ export class ExportToViewService {
     result = await this.destinationPrisma.assetContact.createMany({ data: filteredAssets.assetContacts });
     log(`Created ${result.count} assetContacts.`, 'batch');
 
-    // Export files that belong to the published assets (filtered by type based on publish config)
-    if (filteredAssets.filesToExport.length > 0) {
-      result = await this.destinationPrisma.file.createMany({
-        data: filteredAssets.filesToExport,
-        skipDuplicates: true,
-      });
-      log(`Created ${result.count} files.`, 'batch');
-    }
-
     const geometriesToPublish = assetIds.filter((f) => this.publicAssetConfigs.get(f)?.publishData.geometries);
     for (const [idx, batch] of this.batchList(geometriesToPublish, BATCH_SIZE_GEOMETRIES).entries()) {
       log(`Creating batch #${idx + 1} of geometries`, 'batch');
@@ -176,6 +186,112 @@ export class ExportToViewService {
       await this.exportGeometries(batch, 'study_trace');
       log(`Finished batch #${idx + 1} of geometries`, 'batch');
     }
+  }
+
+  /**
+   * Export the publishable files of the given assets in a memory-bounded fashion.
+   *
+   * Instead of loading every file (including its large JSON columns `fulltextContent`, `pageRangeClassifications`
+   * and `pageDimensions`) for the whole asset batch at once, this method:
+   *   1. determines which file *types* are publishable per asset (Normal / Legal) from the publish config;
+   *   2. filters the publishable files in the *database* (never loading the large columns of non-publishable files);
+   *   3. fetches only the file ids first;
+   *   4. then, one fixed-size chunk at a time, fetches those full rows, transforms them, inserts them, and drops the
+   *      references before fetching the next chunk.
+   *
+   * No file rows are accumulated across fetch iterations: at most one {@link FILE_CHUNK_SIZE}-sized batch is processed at a time.
+   * The publication rules are preserved exactly: `Normal` files are exported for assets whose config has
+   * `normalFiles`, `Legal` files for assets whose config has `legalFiles`.
+   */
+  private async exportFiles(assetIds: number[], batchNumber: number) {
+    const normalFileAssetIds = assetIds.filter((id) => this.publicAssetConfigs.get(id)?.publishData.normalFiles);
+    const legalFileAssetIds = assetIds.filter((id) => this.publicAssetConfigs.get(id)?.publishData.legalFiles);
+
+    const typeFilters: Prisma.FileWhereInput[] = [];
+    if (normalFileAssetIds.length > 0) {
+      typeFilters.push({ assetId: { in: normalFileAssetIds }, type: 'Normal' });
+    }
+    if (legalFileAssetIds.length > 0) {
+      typeFilters.push({ assetId: { in: legalFileAssetIds }, type: 'Legal' });
+    }
+
+    if (typeFilters.length === 0) {
+      return;
+    }
+
+    const where: Prisma.FileWhereInput = { OR: typeFilters };
+
+    // Only fetch the ids first: this keeps the "which files to export" list cheap and lets us pull the heavy rows in
+    // small, fixed-size chunks below.
+    const fileIdRows = await this.sourcePrisma.file.findMany({
+      where,
+      select: { id: true },
+      orderBy: { id: 'asc' },
+    });
+    const fileIds = fileIdRows.map((row) => row.id);
+
+    if (fileIds.length === 0) {
+      return;
+    }
+
+    let totalCreated = 0;
+
+    for (const [chunkIndex, idChunk] of this.batchList(fileIds, FILE_CHUNK_SIZE).entries()) {
+      const chunkNumber = chunkIndex + 1;
+      const memoryContext = { batch: batchNumber, chunk: chunkNumber, ids: idChunk.length };
+
+      this.logMemoryUsage('before files', memoryContext);
+
+      const files = await this.sourcePrisma.file.findMany({
+        where: { id: { in: idChunk } },
+        orderBy: { id: 'asc' },
+      });
+      this.logMemoryUsage('after file fetch', { ...memoryContext, fetched: files.length });
+
+      const inputs: Prisma.FileCreateManyInput[] = files.map((file) => ({
+        ...file,
+        pageRangeClassifications: file.pageRangeClassifications as Prisma.InputJsonValue,
+        fulltextContent: file.fulltextContent as Prisma.InputJsonValue,
+        pageDimensions: file.pageDimensions as Prisma.InputJsonValue,
+      }));
+
+      const result = await this.destinationPrisma.file.createMany({ data: inputs, skipDuplicates: true });
+      totalCreated += result.count;
+      this.logMemoryUsage('after file insert', { ...memoryContext, inserted: result.count });
+
+      // `files` and `inputs` go out of scope on the next iteration, so at most one chunk of heavy rows is retained.
+    }
+
+    this.logMemoryUsage(`after files of batch #${batchNumber}`, {
+      batch: batchNumber,
+      files: fileIds.length,
+      created: totalCreated,
+    });
+  }
+
+  /**
+   * Log the current process memory usage together with the V8 heap limit and optional extra context. Emitted at
+   * batch boundaries and around each file chunk so heap growth can be correlated with batch number, chunk number and
+   * file counts. Deliberately avoids serializing file contents (no JSON.stringify) so that logging cannot itself
+   * allocate large temporaries.
+   */
+  private logMemoryUsage(context: string, extra: Record<string, number | string> = {}) {
+    const mem = process.memoryUsage();
+    const heapLimit = getHeapStatistics().heap_size_limit;
+    const parts = [
+      `rss=${this.formatBytes(mem.rss)}`,
+      `heapUsed=${this.formatBytes(mem.heapUsed)}`,
+      `heapTotal=${this.formatBytes(mem.heapTotal)}`,
+      `external=${this.formatBytes(mem.external)}`,
+      `arrayBuffers=${this.formatBytes(mem.arrayBuffers)}`,
+      `heapLimit=${this.formatBytes(heapLimit)}`,
+      ...Object.entries(extra).map(([key, value]) => `${key}=${value}`),
+    ];
+    log(`Memory [${context}] ${parts.join(' ')}`, 'batch');
+  }
+
+  private formatBytes(bytes: number): string {
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
   }
 
   /**
@@ -349,12 +465,10 @@ export class ExportToViewService {
   private preparePublishedData(assets: PublishedAssetSelection[]): {
     assets: Prisma.AssetCreateManyInput[];
     assetContacts: Prisma.AssetContactCreateManyInput[];
-    filesToExport: Prisma.FileCreateManyInput[];
   } {
     const filteredAssets: Prisma.AssetCreateManyInput[] = [];
-    const filteredFiles: Prisma.FileCreateManyInput[] = [];
     const filteredAssetContacts: Prisma.AssetContactCreateManyInput[] = [];
-    for (const { files, assetContacts, ...asset } of assets) {
+    for (const { assetContacts, ...asset } of assets) {
       const publicAssetConfig = this.publicAssetConfigs.get(asset.assetId);
       if (publicAssetConfig === undefined) {
         continue;
@@ -370,31 +484,6 @@ export class ExportToViewService {
       }
       if (publishData.suppliers) {
         filteredAssetContacts.push(...assetContacts.filter((c) => c.role === 'supplier'));
-      }
-
-      if (publishData.legalFiles) {
-        filteredFiles.push(
-          ...files
-            .filter((f) => f.type === 'Legal')
-            .map((f) => ({
-              ...f,
-              pageRangeClassifications: f.pageRangeClassifications as Prisma.InputJsonValue,
-              fulltextContent: f.fulltextContent as Prisma.InputJsonValue,
-              pageDimensions: f.pageDimensions as Prisma.InputJsonValue,
-            })),
-        );
-      }
-      if (publishData.normalFiles) {
-        filteredFiles.push(
-          ...files
-            .filter((f) => f.type === 'Normal')
-            .map((f) => ({
-              ...f,
-              pageRangeClassifications: f.pageRangeClassifications as Prisma.InputJsonValue,
-              fulltextContent: f.fulltextContent as Prisma.InputJsonValue,
-              pageDimensions: f.pageDimensions as Prisma.InputJsonValue,
-            })),
-        );
       }
 
       const filteredAsset: Prisma.AssetCreateManyInput = {
@@ -416,7 +505,6 @@ export class ExportToViewService {
     return {
       assets: filteredAssets,
       assetContacts: filteredAssetContacts,
-      filesToExport: filteredFiles,
     };
   }
 }


### PR DESCRIPTION
Hopefully a robuster fix for #1022 

Prevent JavaScript heap exhaustion (FATAL ERROR: Reached heap limit)
during the view sync by streaming file export instead of loading and
transforming every file of an asset batch at once.

- Drop `files: true` from the main asset query and stop building a file
  array in preparePublishedData(); the source result, transformed copies
  and Prisma insert payload are no longer retained simultaneously.
- Add exportFiles(), called from the outer batch loop after exportAssets()
  so the asset/contact arrays are collectible before file rows are fetched.
- Filter publishable files in the database (Normal for normalFiles assets,
  Legal for legalFiles assets); non-publishable files never load their
  large JSON columns (fulltextContent, pageRangeClassifications,
  pageDimensions).
- Fetch ids first, then process in fixed chunks of FILE_CHUNK_SIZE (10):
  fetch -> transform -> insert (skipDuplicates) -> drop refs -> next chunk.
- Add process.memoryUsage()/V8 heap-limit diagnostics per chunk and per
  asset batch; no payload-size estimation, no global.gc(), no reliance on
  --max-old-space-size.