### PR TITLE
Fix/assets-1030-partially-inconsistent-behavior-on-view-change

### DIFF
--- a/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.ts
+++ b/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.ts
@@ -91,6 +91,13 @@ export class AssetSearchResultsComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
+    // Cancel any debounced scroll-offset save that is still pending. Without this, a save
+    // scheduled just before a tab switch could run after `favoritesOnly` has flipped and be
+    // routed to the wrong view's scroll offset.
+    if (this.timeoutForSetOffset !== null) {
+      clearTimeout(this.timeoutForSetOffset);
+      this.timeoutForSetOffset = null;
+    }
     this.subscriptions.unsubscribe();
   }
 

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.spec.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.spec.ts
@@ -8,6 +8,8 @@ jest.mock('@asset-sg/client-shared', () => {
   return {
     appSharedStateActions: {
       setCurrentAsset: store.createAction('[Asset Search] Set Current Asset', store.props()),
+      removeAsset: store.createAction('[Asset Shared] Remove Asset', store.props()),
+      updateAsset: store.createAction('[Asset Shared] Update Asset', store.props()),
     },
     fromAppShared: {
       selectCurrentAsset: stubSelector,
@@ -27,6 +29,11 @@ jest.mock('../components/map/map-controller', () => ({
   MapController: class MockMapController {},
 }));
 
+// The state reducer pulls in OpenLayers (ESM) purely for geometry-center helpers that are
+// irrelevant to these tests, so we stub those modules to keep the reducer importable.
+jest.mock('ol/extent', () => ({ getCenter: jest.fn(() => [0, 0]) }));
+jest.mock('ol/geom', () => ({ LineString: class {}, Polygon: class {} }));
+
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import {
@@ -39,8 +46,13 @@ import {
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 
-import { PanelState } from '../state/asset-search/asset-search.actions';
-import { AppStateWithAssetSearch, AssetSearchState } from '../state/asset-search/asset-search.reducer';
+import { PanelState, setScrollOffsetForResults } from '../state/asset-search/asset-search.actions';
+import {
+  assetSearchReducer,
+  AppStateWithAssetSearch,
+  AssetSearchState,
+} from '../state/asset-search/asset-search.reducer';
+import { selectScrollOffsetForResults } from '../state/asset-search/asset-search.selector';
 import { AssetSearchService } from './asset-search.service';
 import { GeometryService } from './geometry.service';
 import { isFavoritesOnlyChange, ViewerControllerService } from './viewer-controller.service';
@@ -69,6 +81,7 @@ const makeSearchState = (overrides: Partial<AssetSearchState['ui']> = {}): Asset
       map: { x: 1, y: 2, z: 3 },
       ...overrides,
     },
+    scrollOffsetForFavorites: 0,
     isLoadingGeometries: false,
     isLoadingResults: false,
     isLoadingFileResults: false,
@@ -182,5 +195,67 @@ describe(ViewerControllerService.name, () => {
     expect(resetAsset?.asset).toBeNull();
     // ...and recomputes the results panel state (open, since there are results).
     expect(types).toContain(SET_RESULTS_STATE);
+  });
+});
+
+describe('result-list scroll offset decoupling (Filter vs Favorites)', () => {
+  const favoritesQuery = { type: SearchType.Asset, favoritesOnly: true } as const;
+
+  describe('reducer', () => {
+    it('routes the offset to the Filter view when not in favorites mode', () => {
+      const state = makeSearchState({ scrollOffsetForResults: 0 });
+
+      const next = assetSearchReducer(state, setScrollOffsetForResults({ offset: 1000 }));
+
+      expect(next.ui.scrollOffsetForResults).toBe(1000);
+      expect(next.scrollOffsetForFavorites).toBe(0);
+    });
+
+    it('routes the offset to the Favorites view when in favorites mode', () => {
+      const state: AssetSearchState = { ...makeSearchState({ scrollOffsetForResults: 500 }), query: favoritesQuery };
+
+      const next = assetSearchReducer(state, setScrollOffsetForResults({ offset: 1000 }));
+
+      expect(next.scrollOffsetForFavorites).toBe(1000);
+      // The Filter view's offset must remain untouched.
+      expect(next.ui.scrollOffsetForResults).toBe(500);
+    });
+
+    it('keeps the Filter scroll position when scrolling in the Favorites view', () => {
+      // Filter view scrolled to 1000.
+      let state = assetSearchReducer(
+        makeSearchState({ scrollOffsetForResults: 0 }),
+        setScrollOffsetForResults({ offset: 1000 }),
+      );
+      // Switch to the Favorites tab and scroll there.
+      state = assetSearchReducer(
+        { ...state, query: { ...state.query, favoritesOnly: true } },
+        setScrollOffsetForResults({ offset: 200 }),
+      );
+
+      expect(state.ui.scrollOffsetForResults).toBe(1000);
+      expect(state.scrollOffsetForFavorites).toBe(200);
+    });
+  });
+
+  describe('selector', () => {
+    it('returns the Filter offset in Filter mode', () => {
+      const state: AssetSearchState = {
+        ...makeSearchState({ scrollOffsetForResults: 1000 }),
+        scrollOffsetForFavorites: 200,
+      };
+
+      expect(selectScrollOffsetForResults.projector(state)).toBe(1000);
+    });
+
+    it('returns the Favorites offset in Favorites mode', () => {
+      const state: AssetSearchState = {
+        ...makeSearchState({ scrollOffsetForResults: 1000 }),
+        query: favoritesQuery,
+        scrollOffsetForFavorites: 200,
+      };
+
+      expect(selectScrollOffsetForResults.projector(state)).toBe(200);
+    });
   });
 });

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.spec.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.spec.ts
@@ -1,0 +1,186 @@
+// The viewer controller transitively imports the `@asset-sg/client-shared` barrel and the
+// OpenLayers-based map controller, both of which pull in ESM modules that Jest does not transform.
+// We only need a handful of lightweight actions/selectors from them for these unit tests, so we
+// stub the heavy modules (matching the pattern used by other component/service specs in the repo).
+jest.mock('@asset-sg/client-shared', () => {
+  const store = jest.requireActual('@ngrx/store');
+  const stubSelector = () => null;
+  return {
+    appSharedStateActions: {
+      setCurrentAsset: store.createAction('[Asset Search] Set Current Asset', store.props()),
+    },
+    fromAppShared: {
+      selectCurrentAsset: stubSelector,
+      selectHasCurrentAsset: stubSelector,
+      selectReferenceContacts: stubSelector,
+      selectReferenceData: stubSelector,
+      selectWorkgroups: stubSelector,
+      selectUser: stubSelector,
+      selectIsAnonymousMode: stubSelector,
+    },
+    LanguageService: class MockLanguageService {},
+  };
+});
+
+jest.mock('../components/map/map-controller', () => ({
+  DEFAULT_MAP_POSITION: { x: 2660000, y: 1190000, z: 8 },
+  MapController: class MockMapController {},
+}));
+
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import {
+  AssetSearchQuery,
+  AssetSearchResult,
+  makeEmptyAssetSearchStats,
+  makeEmptyFileSearchResults,
+  SearchType,
+} from '@asset-sg/shared/v2';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
+
+import { PanelState } from '../state/asset-search/asset-search.actions';
+import { AppStateWithAssetSearch, AssetSearchState } from '../state/asset-search/asset-search.reducer';
+import { AssetSearchService } from './asset-search.service';
+import { GeometryService } from './geometry.service';
+import { isFavoritesOnlyChange, ViewerControllerService } from './viewer-controller.service';
+import { ViewerParamsService } from './viewer-params.service';
+
+const SET_CURRENT_ASSET = '[Asset Search] Set Current Asset';
+const SET_RESULTS_STATE = '[Asset Search] Set Results Open';
+
+const makeResults = (count: number): AssetSearchResult => ({
+  page: { size: count, offset: 0, total: count },
+  // The content of the items is irrelevant for these tests.
+  data: Array.from({ length: count }, (_, i) => ({ id: i + 1 }) as never),
+});
+
+const makeSearchState = (overrides: Partial<AssetSearchState['ui']> = {}): AssetSearchState =>
+  ({
+    query: { type: SearchType.Asset },
+    geometries: [],
+    results: makeResults(5),
+    fileResults: makeEmptyFileSearchResults(),
+    stats: makeEmptyAssetSearchStats(),
+    ui: {
+      filtersState: PanelState.OpenedAutomatically,
+      resultsState: PanelState.OpenedAutomatically,
+      scrollOffsetForResults: 500,
+      map: { x: 1, y: 2, z: 3 },
+      ...overrides,
+    },
+    isLoadingGeometries: false,
+    isLoadingResults: false,
+    isLoadingFileResults: false,
+    isLoadingStats: false,
+  }) as AssetSearchState;
+
+describe('isFavoritesOnlyChange', () => {
+  it('returns true when only favoritesOnly is toggled on', () => {
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro' };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: true };
+    expect(isFavoritesOnlyChange(previous, current)).toBe(true);
+  });
+
+  it('returns true when only favoritesOnly is toggled off', () => {
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: true };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: false };
+    expect(isFavoritesOnlyChange(previous, current)).toBe(true);
+  });
+
+  it('treats undefined and false favoritesOnly as equivalent (no change)', () => {
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro' };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: false };
+    expect(isFavoritesOnlyChange(previous, current)).toBe(false);
+  });
+
+  it('returns false when a search filter changed as well', () => {
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro' };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'geo', favoritesOnly: true };
+    expect(isFavoritesOnlyChange(previous, current)).toBe(false);
+  });
+
+  it('returns false when nothing changed', () => {
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: true };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: true };
+    expect(isFavoritesOnlyChange(previous, current)).toBe(false);
+  });
+});
+
+describe(ViewerControllerService.name, () => {
+  let service: ViewerControllerService;
+  let store: MockStore<AppStateWithAssetSearch>;
+  let assetSearchService: { search: jest.Mock; searchStats: jest.Mock };
+  let dispatchSpy: jest.SpyInstance;
+
+  const setup = (ui?: Partial<AssetSearchState['ui']>) => {
+    assetSearchService = {
+      search: jest.fn().mockReturnValue(of(makeResults(5))),
+      searchStats: jest.fn().mockReturnValue(of(makeEmptyAssetSearchStats())),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ViewerControllerService,
+        provideMockStore({ initialState: { assetSearch: makeSearchState(ui) } as AppStateWithAssetSearch }),
+        { provide: AssetSearchService, useValue: assetSearchService },
+        { provide: ViewerParamsService, useValue: {} },
+        { provide: GeometryService, useValue: {} },
+        { provide: Router, useValue: { events: of() } },
+      ],
+    });
+
+    service = TestBed.inject(ViewerControllerService);
+    store = TestBed.inject(MockStore);
+    dispatchSpy = jest.spyOn(store, 'dispatch');
+  };
+
+  const dispatchedTypes = (): string[] => dispatchSpy.mock.calls.map(([action]) => (action as { type: string }).type);
+
+  const updateByQuery = (current: AssetSearchQuery, previous: AssetSearchQuery): Promise<void> =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).updateByQuery(current, previous);
+
+  it('preserves the selected asset and results panel when toggling favoritesOnly', async () => {
+    setup();
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro' };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: true };
+
+    await updateByQuery(current, previous);
+
+    const types = dispatchedTypes();
+    // The selected asset must not be reset when switching to the Favorites tab.
+    expect(types).not.toContain(SET_CURRENT_ASSET);
+    // The results panel state must be preserved across the tab switch.
+    expect(types).not.toContain(SET_RESULTS_STATE);
+  });
+
+  it('does not auto-select even when the favorites result set has a single asset', async () => {
+    setup();
+    assetSearchService.search.mockReturnValue(of(makeResults(1)));
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro' };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro', favoritesOnly: true };
+
+    await updateByQuery(current, previous);
+
+    expect(dispatchedTypes()).not.toContain(SET_CURRENT_ASSET);
+  });
+
+  it('resets the selected asset and recomputes the results panel on an actual search change', async () => {
+    setup();
+    const previous: AssetSearchQuery = { type: SearchType.Asset, text: 'hydro' };
+    const current: AssetSearchQuery = { type: SearchType.Asset, text: 'geo' };
+
+    await updateByQuery(current, previous);
+
+    const types = dispatchedTypes();
+    // A real search change resets the previously selected asset...
+    expect(types).toContain(SET_CURRENT_ASSET);
+    const resetAsset = dispatchSpy.mock.calls
+      .map(([action]) => action as { type: string; asset?: unknown })
+      .find((action) => action.type === SET_CURRENT_ASSET);
+    expect(resetAsset?.asset).toBeNull();
+    // ...and recomputes the results panel state (open, since there are results).
+    expect(types).toContain(SET_RESULTS_STATE);
+  });
+});

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -369,11 +369,13 @@ export class ViewerControllerService {
 
   private updateStoreByParams(params: ViewerParams): Promise<void> {
     const { ui, query, assetId } = params;
+    // `setQuery` must be dispatched before `setScrollOffsetForResults`, so that the reducer
+    // routes the offset to the view (Filter or Favorites) that this navigation targets.
+    this.store.dispatch(setQuery({ query }));
     this.store.dispatch(setScrollOffsetForResults({ offset: ui.scrollOffsetForResults }));
     this.store.dispatch(setFiltersState({ state: ui.filtersState }));
     this.store.dispatch(setResultsState({ state: ui.resultsState }));
     this.store.dispatch(setMapPosition({ position: ui.map }));
-    this.store.dispatch(setQuery({ query }));
     return this.loadAsset(assetId);
   }
 }

--- a/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-controller.service.ts
@@ -150,7 +150,7 @@ export class ViewerControllerService {
 
   private async loadResults(
     query: SearchQueries,
-    options: { force?: boolean; skipAssetReset?: boolean } = {},
+    options: { force?: boolean; skipAssetReset?: boolean; preserveCurrentAsset?: boolean } = {},
   ): Promise<void> {
     // Always load results when favoritesOnly is true, even if other search criteria are empty
     if (!options.force && isEmptySearchQuery(query) && !query.favoritesOnly) {
@@ -165,6 +165,11 @@ export class ViewerControllerService {
         this.store.dispatch(actions.setAssetsResults({ isLoading: true }));
         const results = await firstValueFrom(this.assetSearchService.search(query));
         this.store.dispatch(actions.setAssetsResults({ results, isLoading: false }));
+        // When preserving the current asset (e.g. when only toggling `favoritesOnly`),
+        // we neither auto-select a single result nor reset the selection.
+        if (options.preserveCurrentAsset) {
+          break;
+        }
         if (results.data.length === 1) {
           await this.loadAsset(results.data[0].id);
         } else if (!options.skipAssetReset) {
@@ -228,9 +233,16 @@ export class ViewerControllerService {
     if (!previousQuery) {
       return;
     }
+
+    // Toggling `favoritesOnly` corresponds to switching between the Filter and Favorites tabs.
+    // This is a view switch, not a change to the search filters, so it must not discard the
+    // user-established view state (selected asset, results panel, scroll offset, map position).
+    // We only reload the data that depends on the favorites flag and otherwise preserve the UI.
+    const isFavoritesToggle = isFavoritesOnlyChange(previousQuery, query);
+
     const currentResultsState = await firstValueFrom(this.store.select(selectResultsState));
     const isSearchQueryEmpty = isEmptySearchQuery(query);
-    if (isSearchQueryEmpty && !query.favoritesOnly) {
+    if (!isFavoritesToggle && isSearchQueryEmpty && !query.favoritesOnly) {
       // Only reset map position if the query is empty and not in favorites mode
       this.store.dispatch(actions.setMapPosition({ position: DEFAULT_MAP_POSITION }));
     }
@@ -238,11 +250,20 @@ export class ViewerControllerService {
     // Load results and stats in parallel, plus geometries if search type changed.
     await Promise.all([
       this.loadResults(query, {
-        force: !isPanelAutomaticallyToggled(currentResultsState) && isPanelOpen(currentResultsState),
+        force: isFavoritesToggle
+          ? isPanelOpen(currentResultsState)
+          : !isPanelAutomaticallyToggled(currentResultsState) && isPanelOpen(currentResultsState),
+        preserveCurrentAsset: isFavoritesToggle,
       }),
       this.loadStats(query),
       ...(previousQuery?.type !== query.type ? [this.loadGeometries(query.type)] : []),
     ]);
+
+    // A favorites toggle preserves the results panel state as-is; the panel should only
+    // open/close on an actual search change or when the user toggles it manually.
+    if (isFavoritesToggle) {
+      return;
+    }
 
     // Use file results total for file search, asset results total for asset search.
     const total =
@@ -356,3 +377,16 @@ export class ViewerControllerService {
     return this.loadAsset(assetId);
   }
 }
+
+/**
+ * Determines whether the only difference between two queries is the `favoritesOnly` flag.
+ * This corresponds to a Filter <-> Favorites tab switch, as opposed to a change of the search filters.
+ */
+export const isFavoritesOnlyChange = (previous: SearchQueries, current: SearchQueries): boolean => {
+  if (Boolean(previous.favoritesOnly) === Boolean(current.favoritesOnly)) {
+    return false;
+  }
+  const { favoritesOnly: _previousFavoritesOnly, ...previousRest } = previous;
+  const { favoritesOnly: _currentFavoritesOnly, ...currentRest } = current;
+  return JSON.stringify(previousRest) === JSON.stringify(currentRest);
+};

--- a/libs/asset-viewer/src/lib/services/viewer-params.service.ts
+++ b/libs/asset-viewer/src/lib/services/viewer-params.service.ts
@@ -13,6 +13,7 @@ import {
   AppStateWithAssetSearch,
   AssetSearchState,
   AssetSearchUiState,
+  getActiveScrollOffset,
 } from '../state/asset-search/asset-search.reducer';
 
 @Injectable({ providedIn: 'root' })
@@ -26,10 +27,14 @@ export class ViewerParamsService {
       this.store.pipe(map((store) => [store.assetSearch, store.shared] as [AssetSearchState, AppSharedState])),
     );
 
+    // `ViewerParams`/URL only carry a single result-list scroll offset, always for the currently
+    // active view. The Favorites view keeps its offset separately, so we normalize it here.
+    const scrollOffsetForResults = getActiveScrollOffset(searchState);
+
     return {
       assetId: sharedState.currentAsset?.asset.id ?? null,
       query: searchState.query,
-      ui: searchState.ui,
+      ui: { ...searchState.ui, scrollOffsetForResults },
     };
   }
 

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.reducer.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.reducer.ts
@@ -30,6 +30,16 @@ export interface AssetSearchState {
   geometries: Geometry[];
   ui: AssetSearchUiState;
 
+  /**
+   * The result-list scroll offset for the Favorites view.
+   *
+   * The Filter and Favorites tabs share this state slice but represent two independent views.
+   * Their result-list scroll positions must therefore be tracked separately, so that scrolling
+   * in one tab does not overwrite the remembered scroll position of the other. The Filter view's
+   * offset lives in {@link AssetSearchUiState.scrollOffsetForResults}, the Favorites view's here.
+   */
+  scrollOffsetForFavorites: number;
+
   fileResults: FileSearchResult;
   isLoadingFileResults: boolean;
 
@@ -62,11 +72,27 @@ const initialState: AssetSearchState = {
     map: DEFAULT_MAP_POSITION,
   },
 
+  scrollOffsetForFavorites: 0,
+
   isLoadingGeometries: false,
   isLoadingResults: false,
   isLoadingFileResults: false,
   isLoadingStats: false,
 };
+
+/**
+ * The Filter and Favorites tabs share this state slice but are two independent views, each with its
+ * own result-list scroll position. These two helpers are the single source of truth for mapping the
+ * currently active view (determined by `query.favoritesOnly`) to its scroll offset, so the reducer,
+ * selector, and URL serialization all stay in sync.
+ */
+export const getActiveScrollOffset = (state: AssetSearchState): number =>
+  state.query.favoritesOnly ? state.scrollOffsetForFavorites : state.ui.scrollOffsetForResults;
+
+export const setActiveScrollOffset = (state: AssetSearchState, offset: number): AssetSearchState =>
+  state.query.favoritesOnly
+    ? { ...state, scrollOffsetForFavorites: offset }
+    : { ...state, ui: { ...state.ui, scrollOffsetForResults: offset } };
 
 export const assetSearchReducer = createReducer(
   initialState,
@@ -142,12 +168,7 @@ export const assetSearchReducer = createReducer(
       ui: { ...state.ui, resultsState },
     }),
   ),
-  on(actions.setScrollOffsetForResults, (state, { offset }): AssetSearchState => {
-    return {
-      ...state,
-      ui: { ...state.ui, scrollOffsetForResults: offset },
-    };
-  }),
+  on(actions.setScrollOffsetForResults, (state, { offset }): AssetSearchState => setActiveScrollOffset(state, offset)),
   on(actions.setMapPosition, (state, { position }): AssetSearchState => {
     return {
       ...state,

--- a/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
+++ b/libs/asset-viewer/src/lib/state/asset-search/asset-search.selector.ts
@@ -17,7 +17,7 @@ import { createSelector } from '@ngrx/store';
 
 import { WorkflowStatus } from '@swissgeol/ui-core';
 import { isPanelOpen } from './asset-search.actions';
-import { AppStateWithAssetSearch } from './asset-search.reducer';
+import { AppStateWithAssetSearch, getActiveScrollOffset } from './asset-search.reducer';
 
 const assetSearchFeature = (state: AppStateWithAssetSearch) => state.assetSearch;
 export const selectFiltersState = createSelector(assetSearchFeature, (state) => state.ui.filtersState);
@@ -30,10 +30,7 @@ export const selectIsResultsOpen = createSelector(selectResultsState, isPanelOpe
 
 export const selectMapPosition = createSelector(assetSearchFeature, (state) => state.ui.map);
 
-export const selectScrollOffsetForResults = createSelector(
-  assetSearchFeature,
-  (state) => state.ui.scrollOffsetForResults,
-);
+export const selectScrollOffsetForResults = createSelector(assetSearchFeature, getActiveScrollOffset);
 
 export const selectSearchQuery = createSelector(assetSearchFeature, (state) => state?.query ?? {});
 

--- a/libs/asset-viewer/src/test-setup.ts
+++ b/libs/asset-viewer/src/test-setup.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
 setupZoneTestEnv();

--- a/libs/client-shared/src/test-setup.ts
+++ b/libs/client-shared/src/test-setup.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
 setupZoneTestEnv();

--- a/libs/shared/v2/src/lib/fixtures/asset.fixtures.ts
+++ b/libs/shared/v2/src/lib/fixtures/asset.fixtures.ts
@@ -1,5 +1,6 @@
-import { LocalDate, WorkflowStatus } from '@swissgeol/ui-core';
+import { WorkflowStatus } from '@swissgeol/ui-core';
 import { Asset } from '../models/asset';
+import { LocalDate } from '../models/base/local-date';
 import { AssetContactRole } from '../models/contact';
 import { PageCategory } from '../models/page-classification';
 import { LanguageCode } from '../models/reference-data';


### PR DESCRIPTION
Switching between the Filter and Favorites tabs is implemented as a
`favoritesOnly` mutation on the shared search query rather than a route
change. The root-singleton ViewerControllerService treated this as a
destructive search change, resetting the selected asset, recomputing and
closing the results panel, and clobbering the scroll position, racing with
the route re-initialization that would otherwise preserve the state (as it
does for the New Asset and Settings tabs).

Detect a `favoritesOnly`-only query change and treat it as a view switch
instead of a filter change: preserve the selected asset (new
`preserveCurrentAsset` option on `loadResults`), the results panel state,
and the map/scroll position. Actual search changes and full search resets
are unaffected and still return to the initial heatmap state.

Add unit tests for both scenarios and enable `reflect-metadata` in the
asset-viewer test setup.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #1030 and #1029 